### PR TITLE
Group pick list by tier instead of rank, add picked-team checkbox

### DIFF
--- a/src/components/OfflineQueue.vue
+++ b/src/components/OfflineQueue.vue
@@ -27,13 +27,15 @@ const retryHandlers = {
         return await upsertPersonalPicklist(
             payload.userId as string,
             payload.eventId as string,
-            payload.teamNumbers as number[]
+            payload.teamNumbers as number[],
+            payload.teamTiers as Record<number, string>
         );
     },
     picklist_team: async (payload: Record<string, unknown>) => {
         return await upsertTeamPicklist(
             payload.eventId as string,
-            payload.teamNumbers as number[]
+            payload.teamNumbers as number[],
+            payload.teamTiers as Record<number, string>
         );
     },
     scout_data: async (payload: Record<string, unknown>) => {

--- a/src/components/PicklistRow.vue
+++ b/src/components/PicklistRow.vue
@@ -1,0 +1,560 @@
+<script setup lang="ts">
+// @ts-nocheck
+import type { TeamEntry } from '@/stores/picklist-store';
+import type { TeamTierStats } from '@/lib/picklist-query';
+
+defineProps<{
+    rowId: string;
+    team: TeamEntry;
+    position: number;
+    showDragHandle: boolean;
+    showVoteStats: boolean;
+    tierStats: TeamTierStats | null;
+    showPicked: boolean;
+    isPicked: boolean;
+    canTogglePicked: boolean;
+    expanded: boolean;
+    expandedData: { stats: unknown[]; comments: unknown[] } | null;
+    expandedLoading: boolean;
+}>();
+
+const emit = defineEmits(['toggle-expand', 'toggle-picked']);
+
+function computeBasicStats(matchData: unknown[]) {
+    if (!matchData.length) return [];
+
+    // Derive numeric fields automatically from the first row
+    const numericFields: string[] = [];
+    if (matchData[0]) {
+        Object.entries(matchData[0]).forEach(([key, val]) => {
+            if (typeof val === 'number' && !key.includes('match_number') && !key.includes('team_number')) {
+                numericFields.push(key);
+            }
+        });
+    }
+
+    return numericFields.slice(0, 8).map((field) => {
+        const values = matchData.map(row => row[field]).filter(v => typeof v === 'number');
+        const avg = values.length ? (values.reduce((a, b) => a + b, 0) / values.length) : 0;
+        const max = values.length ? Math.max(...values) : 0;
+        return { label: formatFieldLabel(field), avg: avg.toFixed(1), max };
+    });
+}
+
+function formatFieldLabel(field: string) {
+    return field
+        .replace(/^(prematch_|postmatch_|auto_|teleop_|endgame_)/g, '')
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function formatAvgRank(avgRank: number) {
+    return avgRank.toFixed(1);
+}
+</script>
+
+<template>
+    <div class="picklist-row" :class="{ 'picklist-row--expanded': expanded, 'picklist-row--picked': isPicked }"
+        :id="rowId">
+        <!-- Collapsed row -->
+        <div class="picklist-row-collapsed" @click="emit('toggle-expand')">
+            <div v-if="showDragHandle" class="picklist-drag-handle" @click.stop title="Drag to reorder">
+                <span class="drag-dots">⠿</span>
+            </div>
+            <div class="picklist-position">{{ position }}</div>
+            <div class="picklist-thumb-wrapper">
+                <img v-if="team.photo_url" :src="team.photo_url" :alt="`Team ${team.team_number} robot`"
+                    class="picklist-thumb" loading="lazy" />
+                <div v-else class="picklist-thumb-placeholder">
+                    <span>🤖</span>
+                </div>
+            </div>
+            <div class="picklist-team-info">
+                <span class="picklist-team-number">{{ team.team_number }}</span>
+                <span class="picklist-team-name">{{ team.name }}</span>
+            </div>
+            <div v-if="showVoteStats" class="picklist-vote-badge" @click.stop>
+                <template v-if="tierStats">
+                    <span class="vote-tier-chip" :class="`tier-chip--${tierStats.tier}`">{{ tierStats.tier }}</span>
+                    <span class="vote-avg" title="Average overall rank across scouts who tiered this team">
+                        avg #{{ formatAvgRank(tierStats.avgRank) }}
+                    </span>
+                    <span class="vote-count">{{ tierStats.votes }} vote{{ tierStats.votes === 1 ? '' : 's' }}</span>
+                </template>
+                <span v-else class="picklist-vote-empty">No picks yet</span>
+            </div>
+            <label v-if="showPicked" class="picklist-picked-check" @click.stop
+                :title="canTogglePicked ? 'Mark as picked' : 'Picked status (leads only)'">
+                <input type="checkbox" :checked="isPicked" :disabled="!canTogglePicked"
+                    @change="emit('toggle-picked')" />
+            </label>
+            <div class="picklist-expand-chevron" :class="{ 'picklist-expand-chevron--open': expanded }">
+                ›
+            </div>
+        </div>
+
+        <!-- Expanded detail -->
+        <transition name="expand">
+            <div v-if="expanded" class="picklist-row-detail">
+                <div v-if="expandedLoading" class="picklist-detail-loading">
+                    <div class="picklist-spinner picklist-spinner--sm"></div> Loading data…
+                </div>
+                <div v-else-if="expandedData" class="picklist-detail-content">
+                    <!-- Full robot image -->
+                    <div class="picklist-detail-photo" v-if="team.photo_url">
+                        <img :src="team.photo_url" :alt="`Team ${team.team_number} robot (full)`"
+                            class="picklist-full-photo" />
+                    </div>
+
+                    <!-- Stats -->
+                    <div class="picklist-detail-section" v-if="expandedData.stats.length > 0">
+                        <h3 class="picklist-detail-heading">Match Stats ({{ expandedData.stats.length }}
+                            matches)</h3>
+                        <div class="picklist-stats-grid">
+                            <div v-for="stat in computeBasicStats(expandedData.stats)" :key="stat.label"
+                                class="picklist-stat-card">
+                                <div class="stat-label">{{ stat.label }}</div>
+                                <div class="stat-avg">{{ stat.avg }}</div>
+                                <div class="stat-sub">avg &nbsp;|&nbsp; max {{ stat.max }}</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div v-else class="picklist-no-data">No match data available.</div>
+
+                    <!-- Comments -->
+                    <div class="picklist-detail-section" v-if="expandedData.comments.length > 0">
+                        <h3 class="picklist-detail-heading">Scout Comments</h3>
+                        <ul class="picklist-comments-list">
+                            <li v-for="(comment, idx) in expandedData.comments" :key="idx" class="picklist-comment">
+                                <div class="comment-meta">
+                                    <span class="comment-author">{{ comment.author }}</span>
+                                    <span class="comment-source-badge">{{ comment.source }}</span>
+                                    <span class="comment-match" v-if="comment.match_number != null">Match
+                                        {{ comment.match_number }}</span>
+                                </div>
+                                <p class="comment-text">{{ comment.comment }}</p>
+                            </li>
+                        </ul>
+                    </div>
+                    <div v-else-if="expandedData.stats.length === 0" class="picklist-no-data">
+                        No scouting data available for this team.
+                    </div>
+                </div>
+            </div>
+        </transition>
+    </div>
+</template>
+
+<style scoped>
+/* ── Row ── */
+.picklist-row {
+    background: var(--tile-background-color);
+    border-radius: 12px;
+    margin-bottom: 8px;
+    overflow: hidden;
+    box-shadow:
+        inset 0 0 0.5px 1px hsla(0, 0%, 100%, 0.07),
+        0 1px 4px hsla(230, 13%, 9%, 0.07),
+        0 2px 10px hsla(230, 13%, 9%, 0.06);
+    transition: box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.picklist-row:hover {
+    box-shadow:
+        inset 0 0 0.5px 1px hsla(0, 0%, 100%, 0.1),
+        0 2px 8px hsla(230, 13%, 9%, 0.12),
+        0 4px 16px hsla(230, 13%, 9%, 0.1);
+}
+
+.picklist-row--expanded {
+    box-shadow:
+        0 0 0 2px #b05703,
+        0 4px 20px hsla(230, 13%, 9%, 0.14);
+}
+
+.picklist-row--ghost {
+    opacity: 0.45;
+}
+
+/* Picked rows are grayed out — dimmed row + desaturated thumbnail — but the
+   checkbox itself stays fully visible so its state is never ambiguous. */
+.picklist-row--picked {
+    opacity: 0.55;
+}
+
+.picklist-row--picked .picklist-thumb {
+    filter: grayscale(85%);
+}
+
+.picklist-row--picked .picklist-picked-check {
+    opacity: 1;
+}
+
+/* Collapsed row layout */
+.picklist-row-collapsed {
+    display: flex;
+    align-items: center;
+    padding: 10px 14px;
+    cursor: pointer;
+    gap: 12px;
+    min-height: 68px;
+    user-select: none;
+}
+
+.picklist-drag-handle {
+    color: rgba(128, 128, 128, 0.5);
+    cursor: grab;
+    font-size: 20px;
+    padding: 4px;
+    flex-shrink: 0;
+    transition: color 0.15s;
+    line-height: 1;
+}
+
+.picklist-drag-handle:hover {
+    color: #b05703;
+}
+
+.picklist-position {
+    font-size: 15px;
+    font-weight: 700;
+    color: #b05703;
+    min-width: 22px;
+    text-align: center;
+    flex-shrink: 0;
+}
+
+.picklist-thumb-wrapper {
+    width: 52px;
+    height: 52px;
+    border-radius: 8px;
+    overflow: hidden;
+    flex-shrink: 0;
+    background: rgba(128, 128, 128, 0.1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.picklist-thumb {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: filter 0.2s ease;
+}
+
+.picklist-thumb-placeholder {
+    font-size: 26px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+}
+
+.picklist-team-info {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+}
+
+.picklist-team-number {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--primary-text-color);
+    line-height: 1.2;
+}
+
+.picklist-team-name {
+    font-size: 13px;
+    color: rgba(128, 128, 128, 0.8);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.picklist-expand-chevron {
+    font-size: 24px;
+    font-weight: 300;
+    color: rgba(128, 128, 128, 0.5);
+    transition: transform 0.22s ease, color 0.15s ease;
+    flex-shrink: 0;
+    line-height: 1;
+    padding-left: 4px;
+}
+
+.picklist-expand-chevron--open {
+    transform: rotate(90deg);
+    color: #b05703;
+}
+
+/* ── Vote badge (Democratic / Team rows) ── */
+.picklist-vote-badge {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+    cursor: default;
+}
+
+.vote-tier-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 5px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 800;
+}
+
+.vote-avg,
+.vote-count {
+    font-size: 11px;
+    color: rgba(128, 128, 128, 0.7);
+    white-space: nowrap;
+}
+
+.picklist-vote-empty {
+    font-size: 11px;
+    color: rgba(128, 128, 128, 0.6);
+    font-style: italic;
+    white-space: nowrap;
+}
+
+/* ── Picked checkbox ── */
+.picklist-picked-check {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    cursor: pointer;
+    padding-left: 2px;
+}
+
+.picklist-picked-check input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: #b05703;
+    cursor: pointer;
+}
+
+.picklist-picked-check input[type="checkbox"]:disabled {
+    cursor: default;
+    opacity: 0.6;
+}
+
+/* ── Detail section ── */
+.picklist-row-detail {
+    border-top: 1px solid rgba(128, 128, 128, 0.15);
+    padding: 16px 14px 20px;
+    overflow: hidden;
+}
+
+.picklist-detail-loading {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: rgba(128, 128, 128, 0.7);
+    padding: 8px 0;
+}
+
+.picklist-spinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid rgba(176, 87, 3, 0.2);
+    border-top-color: #b05703;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+.picklist-spinner--sm {
+    width: 20px;
+    height: 20px;
+    border-width: 2px;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.picklist-detail-content {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.picklist-detail-photo {
+    display: flex;
+    justify-content: center;
+}
+
+.picklist-full-photo {
+    max-width: 340px;
+    width: 100%;
+    border-radius: 10px;
+    object-fit: cover;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+}
+
+.picklist-detail-heading {
+    font-size: 14px;
+    font-weight: 700;
+    color: #b05703;
+    margin-bottom: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.picklist-detail-section {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Stats grid */
+.picklist-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 10px;
+}
+
+.picklist-stat-card {
+    background: rgba(176, 87, 3, 0.08);
+    border: 1px solid rgba(176, 87, 3, 0.2);
+    border-radius: 10px;
+    padding: 10px 12px;
+    text-align: center;
+}
+
+.stat-label {
+    font-size: 11px;
+    color: rgba(128, 128, 128, 0.75);
+    margin-bottom: 4px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.stat-avg {
+    font-size: 22px;
+    font-weight: 700;
+    color: #b05703;
+    line-height: 1.1;
+}
+
+.stat-sub {
+    font-size: 10px;
+    color: rgba(128, 128, 128, 0.6);
+    margin-top: 2px;
+}
+
+/* Comments */
+.picklist-comments-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.picklist-comment {
+    border: 1px solid rgba(128, 128, 128, 0.2);
+    border-radius: 10px;
+    padding: 10px 14px;
+}
+
+.comment-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+    flex-wrap: wrap;
+}
+
+.comment-author {
+    font-weight: 700;
+    font-size: 13px;
+    color: var(--primary-text-color);
+}
+
+.comment-source-badge {
+    font-size: 10px;
+    font-weight: 600;
+    padding: 2px 7px;
+    border-radius: 20px;
+    background: rgba(176, 87, 3, 0.15);
+    color: #b05703;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.comment-match {
+    font-size: 11px;
+    color: rgba(128, 128, 128, 0.6);
+    margin-left: auto;
+}
+
+.comment-text {
+    font-size: 13px;
+    color: var(--primary-text-color);
+    line-height: 1.55;
+    margin: 0;
+}
+
+.picklist-no-data {
+    font-size: 13px;
+    color: rgba(128, 128, 128, 0.6);
+    font-style: italic;
+    padding: 4px 0;
+}
+
+/* Tier chip colors — S best (gold) to DNP worst (red) */
+.tier-chip--S {
+    background: rgba(212, 160, 23, 0.22);
+    color: #b3860f;
+}
+
+.tier-chip--A {
+    background: rgba(58, 158, 58, 0.2);
+    color: #2f8a2f;
+}
+
+.tier-chip--B {
+    background: rgba(58, 120, 200, 0.2);
+    color: #2f6bb0;
+}
+
+.tier-chip--C {
+    background: rgba(140, 100, 200, 0.2);
+    color: #7c53b8;
+}
+
+.tier-chip--D {
+    background: rgba(176, 87, 3, 0.18);
+    color: #b05703;
+}
+
+.tier-chip--DNP {
+    background: rgba(200, 60, 60, 0.2);
+    color: #c33c3c;
+}
+
+/* ── Transitions ── */
+.expand-enter-active,
+.expand-leave-active {
+    transition: max-height 0.28s ease, opacity 0.22s ease;
+    max-height: 1200px;
+    overflow: hidden;
+}
+
+.expand-enter-from,
+.expand-leave-to {
+    max-height: 0;
+    opacity: 0;
+}
+</style>

--- a/src/lib/picklist-query.ts
+++ b/src/lib/picklist-query.ts
@@ -140,13 +140,42 @@ export async function fetchTeamComments(teamNumber: number, eventId: string) {
 }
 
 /**
+ * The tiers a team can be sorted into, best to worst. "DNP" = Do Not Pick.
+ */
+export const TIERS = ['S', 'A', 'B', 'C', 'D', 'DNP'] as const;
+export type Tier = typeof TIERS[number];
+
+/** Display groups for the tier-grouped picklist, including the untriaged bucket. */
+export type TierGroup = 'Unranked' | Tier;
+// "Unranked" (the untriaged pool) renders last, below the real tiers.
+export const TIER_GROUPS: TierGroup[] = [...TIERS, 'Unranked'];
+
+const TIER_INDEX: Record<Tier, number> = { S: 0, A: 1, B: 2, C: 3, D: 4, DNP: 5 };
+
+function isTier(value: unknown): value is Tier {
+    return typeof value === 'string' && (TIERS as readonly string[]).includes(value);
+}
+
+/**
+ * Normalize a raw team_tiers jsonb value (string keys) into a
+ * Record<team_number, Tier>, dropping any invalid entries.
+ */
+export function parseTeamTiers(raw: Record<string, unknown> | null | undefined): Record<number, Tier> {
+    const tiers: Record<number, Tier> = {};
+    Object.entries(raw ?? {}).forEach(([teamNumStr, tier]) => {
+        if (isTier(tier)) tiers[Number(teamNumStr)] = tier;
+    });
+    return tiers;
+}
+
+/**
  * Fetch the current user's personal picklist for an event.
- * Returns the ordered array of team_numbers, or null if none exists.
+ * Returns the ordered array of team_numbers plus tier assignments, or null if none exists.
  */
 export async function fetchPersonalPicklist(userId: string, eventId: string) {
     const { data, error } = await supabase
         .from(pickListTable)
-        .select('id, team_numbers, updated_at')
+        .select('id, team_numbers, team_tiers, updated_at')
         .eq('user_id', userId)
         .eq('event_id', eventId)
         .eq('type', pickListTypePersonal)
@@ -162,12 +191,12 @@ export async function fetchPersonalPicklist(userId: string, eventId: string) {
 
 /**
  * Fetch ALL personal picklists for an event (for the democratic view).
- * Returns array of { user_id, team_numbers }.
+ * Returns array of { user_id, team_numbers, team_tiers }.
  */
 export async function fetchAllPersonalPicklists(eventId: string) {
     const { data, error } = await supabase
         .from(pickListTable)
-        .select('user_id, team_numbers')
+        .select('user_id, team_numbers, team_tiers')
         .eq('event_id', eventId)
         .eq('type', pickListTypePersonal);
 
@@ -179,12 +208,14 @@ export async function fetchAllPersonalPicklists(eventId: string) {
 }
 
 /**
- * Fetch the team (shared lead) picklist for an event.
+ * Fetch the team (shared lead) picklist for an event, including the
+ * event-wide set of teams that have already been picked (real-world
+ * alliance selection), which is only ever stored on this shared row.
  */
 export async function fetchTeamPicklist(eventId: string) {
     const { data, error } = await supabase
         .from(pickListTable)
-        .select('id, team_numbers, updated_at')
+        .select('id, team_numbers, team_tiers, picked_team_numbers, updated_at')
         .eq('event_id', eventId)
         .eq('type', pickListTypeTeam)
         .limit(1)
@@ -198,13 +229,34 @@ export async function fetchTeamPicklist(eventId: string) {
 }
 
 /**
+ * Fetch just the event-wide picked-team set. Visible to every user
+ * regardless of role, unlike the rest of the team list which is lead-only.
+ */
+export async function fetchPickedTeams(eventId: string): Promise<number[]> {
+    const { data, error } = await supabase
+        .from(pickListTable)
+        .select('picked_team_numbers')
+        .eq('event_id', eventId)
+        .eq('type', pickListTypeTeam)
+        .limit(1)
+        .maybeSingle();
+
+    if (error) {
+        console.error('fetchPickedTeams error:', error);
+        return [];
+    }
+    return data?.picked_team_numbers ?? [];
+}
+
+/**
  * Upsert a personal picklist to Supabase.
  * Returns the error object or null on success.
  */
 export async function upsertPersonalPicklist(
     userId: string,
     eventId: string,
-    teamNumbers: number[]
+    teamNumbers: number[],
+    teamTiers: Record<number, Tier>
 ) {
     const { data, error: fetchError } = await supabase
         .from(pickListTable)
@@ -221,6 +273,7 @@ export async function upsertPersonalPicklist(
             .from(pickListTable)
             .update({
                 team_numbers: teamNumbers,
+                team_tiers: teamTiers,
                 updated_at: new Date().toISOString()
             })
             .eq('id', data.id);
@@ -233,6 +286,7 @@ export async function upsertPersonalPicklist(
                 event_id: eventId,
                 type: pickListTypePersonal,
                 team_numbers: teamNumbers,
+                team_tiers: teamTiers,
                 updated_at: new Date().toISOString()
             });
         return error;
@@ -240,10 +294,15 @@ export async function upsertPersonalPicklist(
 }
 
 /**
- * Upsert the shared team picklist to Supabase.
+ * Upsert the shared team picklist to Supabase. Leaves picked_team_numbers
+ * untouched — that's updated separately via updatePickedTeams.
  * Returns the error object or null on success.
  */
-export async function upsertTeamPicklist(eventId: string, teamNumbers: number[]) {
+export async function upsertTeamPicklist(
+    eventId: string,
+    teamNumbers: number[],
+    teamTiers: Record<number, Tier>
+) {
     const { data, error: fetchError } = await supabase
         .from(pickListTable)
         .select('id')
@@ -258,6 +317,7 @@ export async function upsertTeamPicklist(eventId: string, teamNumbers: number[])
             .from(pickListTable)
             .update({
                 team_numbers: teamNumbers,
+                team_tiers: teamTiers,
                 updated_at: new Date().toISOString()
             })
             .eq('id', data.id);
@@ -269,6 +329,7 @@ export async function upsertTeamPicklist(eventId: string, teamNumbers: number[])
                 event_id: eventId,
                 type: pickListTypeTeam,
                 team_numbers: teamNumbers,
+                team_tiers: teamTiers,
                 updated_at: new Date().toISOString()
             });
         return error;
@@ -276,72 +337,128 @@ export async function upsertTeamPicklist(eventId: string, teamNumbers: number[])
 }
 
 /**
- * Compute a democratic ranking from all personal picklists.
- * Each team's score = sum of (total_teams - rank) across all lists.
- * Higher score = higher aggregate ranking.
+ * Update the event-wide picked-team set on the shared team row. This is
+ * intentionally separate from upsertTeamPicklist so toggling a checkbox
+ * never clobbers a concurrently-edited tier/order draft, and vice versa.
+ * Returns the error object or null on success.
  */
-export function computeDemocraticRanking(
-    allLists: { user_id: string; team_numbers: number[] }[]
-): number[] {
-    const scores: Record<number, number> = {};
+export async function updatePickedTeams(eventId: string, pickedTeamNumbers: number[]) {
+    const { data, error: fetchError } = await supabase
+        .from(pickListTable)
+        .select('id')
+        .eq('event_id', eventId)
+        .eq('type', pickListTypeTeam)
+        .maybeSingle();
 
-    allLists.forEach(({ team_numbers }) => {
-        const total = team_numbers.length;
-        team_numbers.forEach((teamNum, idx) => {
-            const score = total - idx; // higher rank = higher score
-            scores[teamNum] = (scores[teamNum] ?? 0) + score;
-        });
-    });
+    if (fetchError) return fetchError;
 
-    return Object.entries(scores)
-        .sort(([, a], [, b]) => b - a)
-        .map(([teamNum]) => Number(teamNum));
+    if (data) {
+        const { error } = await supabase
+            .from(pickListTable)
+            .update({
+                picked_team_numbers: pickedTeamNumbers,
+                updated_at: new Date().toISOString()
+            })
+            .eq('id', data.id);
+        return error;
+    } else {
+        const { error } = await supabase
+            .from(pickListTable)
+            .insert({
+                event_id: eventId,
+                type: pickListTypeTeam,
+                picked_team_numbers: pickedTeamNumbers,
+                updated_at: new Date().toISOString()
+            });
+        return error;
+    }
 }
 
-export interface TeamRankStats {
-    count: number;
-    highest: number; // best (lowest-numbered) 1-indexed rank a scout gave this team
-    lowest: number;  // worst (highest-numbered) 1-indexed rank a scout gave this team
-    mean: number;
-    median: number;
+export interface TeamTierStats {
+    tier: Tier; // aggregate (average) tier across scouts who classified this team
+    votes: number;
+    avgIndex: number; // average of each vote's tier index (0=S..5=DNP) — used to bucket the aggregate tier
+    avgRank: number; // average 1-indexed overall rank across voters' full tiered orderings
+    tierCounts: Record<Tier, number>;
 }
 
 /**
- * Compute per-team rank statistics (highest/lowest/mean/median 1-indexed
- * position) from all personal picklists. Teams a scout didn't include in
- * their list contribute no data point for that scout.
+ * Compute per-team aggregate tier statistics from all personal picklists.
+ * A scout who left a team unranked contributes no data point for it — same
+ * "no vote" convention the old rank stats used, so being untriaged in one
+ * scout's list never drags a team's aggregate down.
+ *
+ * Each list's team_numbers is the tier-grouped flat order (real tiers
+ * first, in S..DNP order, "Unranked" trailing), so a tiered team's index
+ * in that array is already its 1-indexed overall rank among that scout's
+ * *tiered* teams — untriaged teams always sort after it and can't shift it.
  */
-export function computeTeamRankStats(
-    allLists: { user_id: string; team_numbers: number[] }[]
-): Record<number, TeamRankStats> {
+export function computeTeamTierStats(
+    allLists: { user_id: string; team_numbers: number[]; team_tiers: Record<string, unknown> }[]
+): Record<number, TeamTierStats> {
+    const tiersByTeam: Record<number, Tier[]> = {};
     const ranksByTeam: Record<number, number[]> = {};
 
-    allLists.forEach(({ team_numbers }) => {
-        team_numbers.forEach((teamNum, idx) => {
-            const rank = idx + 1;
-            (ranksByTeam[teamNum] ??= []).push(rank);
+    allLists.forEach(({ team_numbers, team_tiers }) => {
+        const tiersMap = parseTeamTiers(team_tiers);
+        (team_numbers ?? []).forEach((teamNumRaw, idx) => {
+            const teamNum = Number(teamNumRaw);
+            const tier = tiersMap[teamNum];
+            if (!tier) return; // left unranked by this scout — no data point
+            (tiersByTeam[teamNum] ??= []).push(tier);
+            (ranksByTeam[teamNum] ??= []).push(idx + 1);
         });
     });
 
-    const stats: Record<number, TeamRankStats> = {};
+    const stats: Record<number, TeamTierStats> = {};
 
-    Object.entries(ranksByTeam).forEach(([teamNumStr, ranks]) => {
+    Object.entries(tiersByTeam).forEach(([teamNumStr, tiers]) => {
         const teamNum = Number(teamNumStr);
-        const sorted = [...ranks].sort((a, b) => a - b);
-        const mean = sorted.reduce((a, b) => a + b, 0) / sorted.length;
-        const mid = Math.floor(sorted.length / 2);
-        const median = sorted.length % 2 === 0
-            ? (sorted[mid - 1] + sorted[mid]) / 2
-            : sorted[mid];
+        const tierCounts = { S: 0, A: 0, B: 0, C: 0, D: 0, DNP: 0 };
+        let sum = 0;
+        tiers.forEach((t) => {
+            tierCounts[t]++;
+            sum += TIER_INDEX[t];
+        });
+        const avgIndex = sum / tiers.length;
+        const bucket = Math.min(TIERS.length - 1, Math.max(0, Math.round(avgIndex)));
+        const ranks = ranksByTeam[teamNum];
+        const avgRank = ranks.reduce((a, b) => a + b, 0) / ranks.length;
 
-        stats[teamNum] = {
-            count: sorted.length,
-            highest: sorted[0],
-            lowest: sorted[sorted.length - 1],
-            mean,
-            median
-        };
+        stats[teamNum] = { tier: TIERS[bucket], votes: tiers.length, avgIndex, avgRank, tierCounts };
     });
 
     return stats;
+}
+
+/**
+ * Group every team into a TierGroup based on computeTeamTierStats output.
+ * Teams with no votes land in "Unranked". Within a real tier, teams are
+ * ordered best-to-worst by average overall placement (avgRank), then by
+ * vote count.
+ */
+export function computeDemocraticTierGroups(
+    allTeamNumbers: number[],
+    stats: Record<number, TeamTierStats>
+): Record<TierGroup, number[]> {
+    const groups: Record<TierGroup, number[]> = {
+        Unranked: [], S: [], A: [], B: [], C: [], D: [], DNP: []
+    };
+
+    allTeamNumbers.forEach((teamNum) => {
+        const s = stats[teamNum];
+        groups[s ? s.tier : 'Unranked'].push(teamNum);
+    });
+
+    TIERS.forEach((tier) => {
+        groups[tier].sort((a, b) => {
+            const sa = stats[a];
+            const sb = stats[b];
+            if (sa.avgRank !== sb.avgRank) return sa.avgRank - sb.avgRank;
+            if (sa.votes !== sb.votes) return sb.votes - sa.votes;
+            return a - b;
+        });
+    });
+
+    return groups;
 }

--- a/src/stores/picklist-store.ts
+++ b/src/stores/picklist-store.ts
@@ -6,14 +6,19 @@ import {
     fetchPersonalPicklist,
     fetchTeamPicklist,
     fetchAllPersonalPicklists,
+    fetchPickedTeams,
     upsertPersonalPicklist,
     upsertTeamPicklist,
-    computeDemocraticRanking,
-    computeTeamRankStats,
+    updatePickedTeams,
+    computeTeamTierStats,
+    computeDemocraticTierGroups,
+    parseTeamTiers,
     fetchTeamMatchStats,
-    fetchTeamComments
+    fetchTeamComments,
+    TIERS,
+    TIER_GROUPS
 } from '@/lib/picklist-query';
-import type { TeamRankStats } from '@/lib/picklist-query';
+import type { Tier, TierGroup, TeamTierStats } from '@/lib/picklist-query';
 
 export type PicklistTab = 'personal' | 'democratic' | 'team';
 
@@ -21,6 +26,40 @@ export interface TeamEntry {
     team_number: number;
     name: string;
     photo_url: string | null;
+}
+
+function emptyTierSections(): Record<TierGroup, number[]> {
+    const groups = {} as Record<TierGroup, number[]>;
+    TIER_GROUPS.forEach((g) => { groups[g] = []; });
+    return groups;
+}
+
+/**
+ * Bucket a saved (order, tier) pair into tier-grouped sections, in saved
+ * order within each tier. Any team present in allTeams but missing from
+ * teamNumbers (e.g. added to the event after this list was last saved)
+ * is appended to "Unranked".
+ */
+function buildTierSections(
+    teamNumbers: number[],
+    tiersMap: Record<number, Tier>,
+    allTeams: TeamEntry[]
+): Record<TierGroup, number[]> {
+    const groups = emptyTierSections();
+    const seen = new Set<number>();
+    const orderSource = teamNumbers.length ? teamNumbers : allTeams.map((t) => t.team_number);
+
+    const place = (num: number) => {
+        if (seen.has(num)) return;
+        seen.add(num);
+        const tier = tiersMap[num];
+        groups[tier ?? 'Unranked'].push(num);
+    };
+
+    orderSource.forEach((num) => place(Number(num)));
+    allTeams.forEach((t) => place(t.team_number));
+
+    return groups;
 }
 
 export const usePicklistStore = defineStore('picklist', {
@@ -33,21 +72,25 @@ export const usePicklistStore = defineStore('picklist', {
             allTeams: [] as TeamEntry[],
             teamsLoaded: false,
 
-            // Personal list — ordered team numbers
-            personalList: [] as number[],
-            personalListId: null as string | null,
+            // Personal list — tier-grouped team numbers, source of truth for order + tier
+            personalTierSections: emptyTierSections(),
             personalListLoaded: false,
 
-            // Team (lead) list — ordered team numbers
-            teamList: [] as number[],
+            // Team (lead) list — tier-grouped team numbers
+            teamTierSections: emptyTierSections(),
             teamListLoaded: false,
 
-            // Democratic list — computed from all personal lists
-            democraticList: [] as number[],
+            // Democratic list — computed (read-only) tier grouping from all personal lists
+            democraticTierSections: emptyTierSections(),
             democraticListLoaded: false,
 
-            // Per-team highest/lowest/mean/median rank across all personal lists
-            teamRankStats: {} as Record<number, TeamRankStats>,
+            // Per-team aggregate tier stats across all personal lists
+            teamTierStats: {} as Record<number, TeamTierStats>,
+
+            // Event-wide "has this team already been picked" set, visible to everyone,
+            // editable by leads only. Lives on the shared team-type PickList row.
+            pickedTeams: [] as number[],
+            pickedTeamsLoaded: false,
 
             // Per-team expanded data cache
             teamDataCache: {} as Record<number, { stats: unknown[]; comments: unknown[] }>,
@@ -59,53 +102,45 @@ export const usePicklistStore = defineStore('picklist', {
         };
     },
     getters: {
-        /**
-         * Returns the active list's team entries in ranked order.
-         * Falls back to all teams (unranked) when the list is empty.
-         */
-        activeOrderedTeams(): TeamEntry[] {
-            let orderedNums: number[];
-
-            if (this.activeTab === 'personal') {
-                orderedNums = this.personalList;
-            } else if (this.activeTab === 'democratic') {
-                orderedNums = this.democraticList;
-            } else {
-                orderedNums = this.teamList;
-            }
-
-            if (orderedNums.length === 0) {
-                return [...this.allTeams];
-            }
-
-            const teamMap: Record<number, TeamEntry> = {};
-            this.allTeams.forEach((t) => {
-                teamMap[t.team_number] = t;
-            });
-
-            const ordered: TeamEntry[] = [];
-            const added = new Set<number>();
-
-            orderedNums.forEach((num) => {
-                const n = Number(num);
-                if (teamMap[n] && !added.has(n)) {
-                    ordered.push(teamMap[n]);
-                    added.add(n);
-                }
-            });
-
-            // Append any teams not yet in the list
-            this.allTeams.forEach((t) => {
-                if (!added.has(t.team_number)) ordered.push(t);
-            });
-
-            return ordered;
+        teamMap(): Record<number, TeamEntry> {
+            const map: Record<number, TeamEntry> = {};
+            this.allTeams.forEach((t) => { map[t.team_number] = t; });
+            return map;
         },
 
-        isActiveListEditable(): boolean {
-            // Personal tab: everyone can edit their own
-            // Team tab: only leads can edit
-            return this.activeTab === 'personal' || this.activeTab === 'team';
+        /** The tier-grouped sections for whichever tab is currently active. */
+        activeSections(): Record<TierGroup, number[]> {
+            if (this.activeTab === 'personal') return this.personalTierSections;
+            if (this.activeTab === 'team') return this.teamTierSections;
+            return this.democraticTierSections;
+        },
+
+        personalFlatOrder(): number[] {
+            return TIER_GROUPS.flatMap((g) => this.personalTierSections[g] ?? []);
+        },
+
+        personalTiersMap(): Record<number, Tier> {
+            const map: Record<number, Tier> = {};
+            TIERS.forEach((tier) => {
+                (this.personalTierSections[tier] ?? []).forEach((num) => { map[num] = tier; });
+            });
+            return map;
+        },
+
+        teamFlatOrder(): number[] {
+            return TIER_GROUPS.flatMap((g) => this.teamTierSections[g] ?? []);
+        },
+
+        teamTiersMap(): Record<number, Tier> {
+            const map: Record<number, Tier> = {};
+            TIERS.forEach((tier) => {
+                (this.teamTierSections[tier] ?? []).forEach((num) => { map[num] = tier; });
+            });
+            return map;
+        },
+
+        isTeamPicked(): (teamNumber: number) => boolean {
+            return (teamNumber: number) => this.pickedTeams.includes(teamNumber);
         }
     },
     actions: {
@@ -116,6 +151,7 @@ export const usePicklistStore = defineStore('picklist', {
         async loadAll(eventId: string, userId: string | null, isLead: boolean) {
             await this.loadTeams(eventId);
             await this.loadPersonalList(userId, eventId);
+            await this.loadPickedTeams(eventId);
             await this.loadDemocraticList(eventId);
             if (isLead) {
                 await this.loadTeamList(eventId);
@@ -131,61 +167,64 @@ export const usePicklistStore = defineStore('picklist', {
         async loadPersonalList(userId: string | null, eventId: string) {
             this.personalListLoaded = false;
             if (!userId) {
-                this.personalList = this.allTeams.map((t) => t.team_number);
+                this.personalTierSections = buildTierSections([], {}, this.allTeams);
                 this.personalListLoaded = true;
                 return;
             }
 
             const result = await fetchPersonalPicklist(userId, eventId);
-            if (result?.team_numbers?.length) {
-                this.personalList = result.team_numbers;
-                this.personalListId = result.id;
-            } else {
-                // Default: use the sorted team list order
-                this.personalList = this.allTeams.map((t) => t.team_number);
-            }
+            this.personalTierSections = buildTierSections(
+                result?.team_numbers ?? [],
+                parseTeamTiers(result?.team_tiers),
+                this.allTeams
+            );
             this.personalListLoaded = true;
         },
 
         async loadTeamList(eventId: string) {
             this.teamListLoaded = false;
             const result = await fetchTeamPicklist(eventId);
-            if (result?.team_numbers?.length) {
-                this.teamList = result.team_numbers;
-            } else {
-                this.teamList = this.allTeams.map((t) => t.team_number);
-            }
+            this.teamTierSections = buildTierSections(
+                result?.team_numbers ?? [],
+                parseTeamTiers(result?.team_tiers),
+                this.allTeams
+            );
             this.teamListLoaded = true;
         },
 
         async loadDemocraticList(eventId: string) {
             this.democraticListLoaded = false;
             const allLists = await fetchAllPersonalPicklists(eventId);
-            this.democraticList = computeDemocraticRanking(allLists);
-            this.teamRankStats = computeTeamRankStats(allLists);
+            this.teamTierStats = computeTeamTierStats(allLists);
+            this.democraticTierSections = computeDemocraticTierGroups(
+                this.allTeams.map((t) => t.team_number),
+                this.teamTierStats
+            );
             this.democraticListLoaded = true;
         },
 
-        setPersonalOrder(orderedNumbers: (number|string)[]) {
-            this.personalList = Array.from(new Set(orderedNumbers.map(Number)));
-        },
-
-        setTeamOrder(orderedNumbers: (number|string)[]) {
-            this.teamList = Array.from(new Set(orderedNumbers.map(Number)));
+        async loadPickedTeams(eventId: string) {
+            this.pickedTeamsLoaded = false;
+            this.pickedTeams = await fetchPickedTeams(eventId);
+            this.pickedTeamsLoaded = true;
         },
 
         /**
-         * Reset the team list to the current democratic ranking, overwriting
-         * whatever order is currently staged for the team list.
+         * Reset the team list's tiers/order to the current democratic
+         * grouping, overwriting whatever is currently staged for the team list.
          */
         resetTeamListFromDemocratic() {
-            this.teamList = [...this.democraticList];
+            const cloned = emptyTierSections();
+            TIER_GROUPS.forEach((g) => { cloned[g] = [...(this.democraticTierSections[g] ?? [])]; });
+            this.teamTierSections = cloned;
         },
 
         async savePersonalList(userId: string, eventId: string) {
             this.isSaving = true;
             this.lastSaveError = null;
-            const error = await upsertPersonalPicklist(userId, eventId, this.personalList);
+            const error = await upsertPersonalPicklist(
+                userId, eventId, this.personalFlatOrder, this.personalTiersMap
+            );
             this.isSaving = false;
             if (error) {
                 this.lastSaveError = error.message ?? 'Unknown error';
@@ -199,7 +238,7 @@ export const usePicklistStore = defineStore('picklist', {
         async saveTeamList(eventId: string) {
             this.isSaving = true;
             this.lastSaveError = null;
-            const error = await upsertTeamPicklist(eventId, this.teamList);
+            const error = await upsertTeamPicklist(eventId, this.teamFlatOrder, this.teamTiersMap);
             this.isSaving = false;
             if (error) {
                 this.lastSaveError = error.message ?? 'Unknown error';
@@ -207,6 +246,27 @@ export const usePicklistStore = defineStore('picklist', {
             }
             this.lastSaveSuccess = true;
             setTimeout(() => { this.lastSaveSuccess = false; }, 3000);
+            return true;
+        },
+
+        /**
+         * Toggle the event-wide picked status for a team. Optimistically
+         * updates local state, reverting if the save fails.
+         */
+        async togglePicked(eventId: string, teamNumber: number) {
+            const previous = this.pickedTeams;
+            const wasPicked = previous.includes(teamNumber);
+            const next = wasPicked
+                ? previous.filter((n) => n !== teamNumber)
+                : [...previous, teamNumber];
+
+            this.pickedTeams = next;
+            const error = await updatePickedTeams(eventId, next);
+            if (error) {
+                this.pickedTeams = previous;
+                this.lastSaveError = error.message ?? 'Unknown error';
+                return false;
+            }
             return true;
         },
 

--- a/src/views/PicklistView.vue
+++ b/src/views/PicklistView.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 // @ts-nocheck
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
+import { ref, computed, onMounted, onUnmounted } from 'vue';
 import draggable from 'vuedraggable';
 import Papa from 'papaparse';
 import { usePicklistStore } from '@/stores/picklist-store';
 import { useAuthStore } from '@/stores/auth-store';
 import { useEventStore } from '@/stores/event-store';
 import { useOfflineQueueStore } from '@/stores/offline-queue-store';
+import { TIER_GROUPS } from '@/lib/picklist-query';
+import PicklistRow from '@/components/PicklistRow.vue';
 
 const picklistStore = usePicklistStore();
 const authStore = useAuthStore();
@@ -109,22 +111,22 @@ const activeTab = computed({
     set: (v) => picklistStore.setTab(v)
 });
 
-// Draggable list binding — sync back into the store on change
-const draggablePersonal = computed({
-    get: () => picklistStore.activeOrderedTeams,
-    set: (newOrder) => {
-        if (picklistStore.activeTab === 'personal') {
-            picklistStore.setPersonalOrder(newOrder.map(t => t.team_number));
-        } else if (picklistStore.activeTab === 'team') {
-            picklistStore.setTeamOrder(newOrder.map(t => t.team_number));
-        }
-    }
-});
-
 const isEditable = computed(() =>
     (activeTab.value === 'personal') ||
     (activeTab.value === 'team' && isLead.value)
 );
+
+// Vote (tier) stats are only meaningful once more than one person's ranking
+// is in play — shown on the Team tab (leads deciding) and the Democratic tab.
+const showVoteStats = computed(() => activeTab.value !== 'personal');
+
+// The picked checkbox reflects real-world alliance selection. It's only
+// shown (and only ever editable) on the official Team tab — not on a
+// scout's own personal draft ranking, and not on the read-only Democratic
+// aggregate.
+const showPickedCheckbox = computed(() => activeTab.value === 'team');
+
+const hasDemocraticVotes = computed(() => Object.keys(picklistStore.teamTierStats).length > 0);
 
 // ─── Loading ───────────────────────────────────────────────────────────────────
 
@@ -151,6 +153,13 @@ async function toggleExpand(teamNumber: number) {
     expandedLoading.value = false;
 }
 
+// ─── Picked toggle ─────────────────────────────────────────────────────────────
+
+async function togglePicked(teamNumber: number) {
+    if (!isLead.value) return;
+    await picklistStore.togglePicked(eventId.value, teamNumber);
+}
+
 // ─── Save ─────────────────────────────────────────────────────────────────────
 
 async function saveList() {
@@ -163,7 +172,8 @@ async function saveList() {
             queueStore.enqueue('picklist_personal', {
                 userId: userId.value,
                 eventId: eventId.value,
-                teamNumbers: picklistStore.personalList
+                teamNumbers: picklistStore.personalFlatOrder,
+                teamTiers: picklistStore.personalTiersMap
             }, picklistStore.lastSaveError ?? undefined);
         }
     } else if (activeTab.value === 'team' && isLead.value) {
@@ -171,7 +181,8 @@ async function saveList() {
         if (!success) {
             queueStore.enqueue('picklist_team', {
                 eventId: eventId.value,
-                teamNumbers: picklistStore.teamList
+                teamNumbers: picklistStore.teamFlatOrder,
+                teamTiers: picklistStore.teamTiersMap
             }, picklistStore.lastSaveError ?? undefined);
         }
     }
@@ -196,11 +207,22 @@ async function resetTeamFromDemocratic() {
 // ─── Export ───────────────────────────────────────────────────────────────────
 
 function exportTeamListCsv() {
-    const rows = picklistStore.activeOrderedTeams.map((team, index) => ({
-        rank: index + 1,
-        team_number: team.team_number,
-        name: team.name
-    }));
+    const rows: Record<string, unknown>[] = [];
+    let rank = 0;
+    TIER_GROUPS.forEach((group) => {
+        (picklistStore.teamTierSections[group] ?? []).forEach((teamNumber) => {
+            const team = picklistStore.teamMap[teamNumber];
+            if (!team) return;
+            rank += 1;
+            rows.push({
+                rank,
+                tier: group,
+                team_number: team.team_number,
+                name: team.name,
+                picked: picklistStore.isTeamPicked(teamNumber)
+            });
+        });
+    });
 
     const csv = Papa.unparse(rows);
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
@@ -215,44 +237,26 @@ function exportTeamListCsv() {
     URL.revokeObjectURL(url);
 }
 
-// ─── Stat helpers ─────────────────────────────────────────────────────────────
+// ─── Tier stats (Democratic / Team tabs) ──────────────────────────────────────
 
-function computeBasicStats(matchData: unknown[]) {
-    if (!matchData.length) return [];
+function tierStatsFor(teamNumber: number) {
+    return picklistStore.teamTierStats[teamNumber] ?? null;
+}
 
-    // Derive numeric fields automatically from the first row
-    const numericFields: string[] = [];
-    if (matchData[0]) {
-        Object.entries(matchData[0]).forEach(([key, val]) => {
-            if (typeof val === 'number' && !key.includes('match_number') && !key.includes('team_number')) {
-                numericFields.push(key);
-            }
-        });
+function tierGroupLabel(group: string) {
+    return group === 'Unranked' ? 'Unranked' : group;
+}
+
+// The orange number is the overall rank across the whole list, not a
+// per-tier count — so it keeps climbing across tier section boundaries.
+function groupRankOffset(group: string) {
+    const sections = picklistStore.activeSections;
+    let offset = 0;
+    for (const g of TIER_GROUPS) {
+        if (g === group) break;
+        offset += (sections[g] ?? []).length;
     }
-
-    return numericFields.slice(0, 8).map((field) => {
-        const values = matchData.map(row => row[field]).filter(v => typeof v === 'number');
-        const avg = values.length ? (values.reduce((a, b) => a + b, 0) / values.length) : 0;
-        const max = values.length ? Math.max(...values) : 0;
-        return { label: formatFieldLabel(field), avg: avg.toFixed(1), max };
-    });
-}
-
-function formatFieldLabel(field: string) {
-    return field
-        .replace(/^(prematch_|postmatch_|auto_|teleop_|endgame_)/g, '')
-        .replace(/_/g, ' ')
-        .replace(/\b\w/g, c => c.toUpperCase());
-}
-
-// ─── Rank stats (Democratic / Team tabs) ──────────────────────────────────────
-
-function rankStatsFor(teamNumber: number) {
-    return picklistStore.teamRankStats[teamNumber] ?? null;
-}
-
-function formatRankNumber(n: number) {
-    return Number.isInteger(n) ? String(n) : n.toFixed(1);
+    return offset;
 }
 </script>
 
@@ -292,10 +296,11 @@ function formatRankNumber(n: number) {
 
             <!-- Tab description -->
             <div class="picklist-tab-description">
-                <span v-if="activeTab === 'personal'">Your personal ranking. Drag rows to reorder, then save.</span>
-                <span v-else-if="activeTab === 'democratic'">Aggregated ranking from all scouts' personal lists
+                <span v-if="activeTab === 'personal'">Your personal tier ranking. Drag rows between tiers or reorder
+                    within a tier, then save.</span>
+                <span v-else-if="activeTab === 'democratic'">Aggregated tier ranking from all scouts' personal lists
                     (read-only).</span>
-                <span v-else>Official team pick list — only leads can edit. Drag to reorder, then save.</span>
+                <span v-else>Official team pick list — only leads can edit. Drag between tiers, then save.</span>
             </div>
 
             <!-- Loading state -->
@@ -316,8 +321,8 @@ function formatRankNumber(n: number) {
                 <!-- Save / status bar -->
                 <div class="picklist-save-bar" v-if="isEditable">
                     <button v-if="activeTab === 'team'" id="btn-reset-democratic" class="picklist-reset-btn"
-                        :disabled="picklistStore.isSaving || picklistStore.democraticList.length === 0"
-                        title="Overwrite the team list with the current democratic ranking" @click="resetTeamFromDemocratic">
+                        :disabled="picklistStore.isSaving || !hasDemocraticVotes"
+                        title="Overwrite the team list with the current democratic tier grouping" @click="resetTeamFromDemocratic">
                         ↺ Reset from Democratic
                     </button>
                     <button v-if="activeTab === 'team'" id="btn-export-team-csv" class="picklist-reset-btn"
@@ -348,202 +353,49 @@ function formatRankNumber(n: number) {
                 </div>
 
                 <!-- Democratic hint -->
-                <div v-if="activeTab === 'democratic' && picklistStore.democraticList.length === 0" class="picklist-empty">
+                <div v-if="activeTab === 'democratic' && !hasDemocraticVotes" class="picklist-empty">
                     <p>No personal lists have been submitted yet — submit yours on the "My List" tab first.</p>
                 </div>
 
-                <!-- Draggable / static list -->
-                <draggable v-if="isEditable" v-model="draggablePersonal" group="picklist" item-key="team_number"
-                    handle=".picklist-drag-handle" animation="200" ghost-class="picklist-row--ghost" :force-fallback="true"
-                    :scroll="false" @start="onDragStart" @end="onDragEnd" @change="saveList">
-                    <template #item="{ element: team, index }">
-                        <div class="picklist-row" :class="{ 'picklist-row--expanded': expandedTeam === team.team_number }"
-                            :id="`picklist-team-${team.team_number}`">
-                            <!-- Collapsed row -->
-                            <div class="picklist-row-collapsed" @click="toggleExpand(team.team_number)">
-                                <div class="picklist-drag-handle" @click.stop title="Drag to reorder">
-                                    <span class="drag-dots">⠿</span>
-                                </div>
-                                <div class="picklist-rank">{{ index + 1 }}</div>
-                                <div class="picklist-thumb-wrapper">
-                                    <img v-if="team.photo_url" :src="team.photo_url" :alt="`Team ${team.team_number} robot`"
-                                        class="picklist-thumb" loading="lazy" />
-                                    <div v-else class="picklist-thumb-placeholder">
-                                        <span>🤖</span>
-                                    </div>
-                                </div>
-                                <div class="picklist-team-info">
-                                    <span class="picklist-team-number">{{ team.team_number }}</span>
-                                    <span class="picklist-team-name">{{ team.name }}</span>
-                                </div>
-                                <div v-if="activeTab === 'team'" class="picklist-rank-stats" @click.stop>
-                                    <template v-if="rankStatsFor(team.team_number)">
-                                        <div class="rank-stat" title="Highest (best) rank across personal lists">
-                                            <span class="rank-stat-label">Hi</span>
-                                            <span class="rank-stat-value">{{ formatRankNumber(rankStatsFor(team.team_number).highest) }}</span>
-                                        </div>
-                                        <div class="rank-stat" title="Lowest (worst) rank across personal lists">
-                                            <span class="rank-stat-label">Lo</span>
-                                            <span class="rank-stat-value">{{ formatRankNumber(rankStatsFor(team.team_number).lowest) }}</span>
-                                        </div>
-                                        <div class="rank-stat" title="Mean rank across personal lists">
-                                            <span class="rank-stat-label">Avg</span>
-                                            <span class="rank-stat-value">{{ formatRankNumber(rankStatsFor(team.team_number).mean) }}</span>
-                                        </div>
-                                        <div class="rank-stat" title="Median rank across personal lists">
-                                            <span class="rank-stat-label">Med</span>
-                                            <span class="rank-stat-value">{{ formatRankNumber(rankStatsFor(team.team_number).median) }}</span>
-                                        </div>
-                                    </template>
-                                    <span v-else class="picklist-rank-stats-empty">No picks yet</span>
-                                </div>
-                                <div class="picklist-expand-chevron"
-                                    :class="{ 'picklist-expand-chevron--open': expandedTeam === team.team_number }">
-                                    ›
-                                </div>
-                            </div>
-
-                            <!-- Expanded detail -->
-                            <transition name="expand">
-                                <div v-if="expandedTeam === team.team_number" class="picklist-row-detail">
-                                    <div v-if="expandedLoading" class="picklist-detail-loading">
-                                        <div class="picklist-spinner picklist-spinner--sm"></div> Loading data…
-                                    </div>
-                                    <div v-else-if="expandedData" class="picklist-detail-content">
-                                        <!-- Full robot image -->
-                                        <div class="picklist-detail-photo" v-if="team.photo_url">
-                                            <img :src="team.photo_url" :alt="`Team ${team.team_number} robot (full)`"
-                                                class="picklist-full-photo" />
-                                        </div>
-
-                                        <!-- Stats -->
-                                        <div class="picklist-detail-section" v-if="expandedData.stats.length > 0">
-                                            <h3 class="picklist-detail-heading">Match Stats ({{ expandedData.stats.length }}
-                                                matches)</h3>
-                                            <div class="picklist-stats-grid">
-                                                <div v-for="stat in computeBasicStats(expandedData.stats)" :key="stat.label"
-                                                    class="picklist-stat-card">
-                                                    <div class="stat-label">{{ stat.label }}</div>
-                                                    <div class="stat-avg">{{ stat.avg }}</div>
-                                                    <div class="stat-sub">avg &nbsp;|&nbsp; max {{ stat.max }}</div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div v-else class="picklist-no-data">No match data available.</div>
-
-                                        <!-- Comments -->
-                                        <div class="picklist-detail-section" v-if="expandedData.comments.length > 0">
-                                            <h3 class="picklist-detail-heading">Scout Comments</h3>
-                                            <ul class="picklist-comments-list">
-                                                <li v-for="(comment, idx) in expandedData.comments" :key="idx"
-                                                    class="picklist-comment">
-                                                    <div class="comment-meta">
-                                                        <span class="comment-author">{{ comment.author }}</span>
-                                                        <span class="comment-source-badge">{{ comment.source }}</span>
-                                                        <span class="comment-match" v-if="comment.match_number != null">Match
-                                                            {{ comment.match_number }}</span>
-                                                    </div>
-                                                    <p class="comment-text">{{ comment.comment }}</p>
-                                                </li>
-                                            </ul>
-                                        </div>
-                                        <div v-else-if="expandedData.stats.length === 0" class="picklist-no-data">
-                                            No scouting data available for this team.
-                                        </div>
-                                    </div>
-                                </div>
-                            </transition>
-                        </div>
-                    </template>
-                </draggable>
-
-                <!-- Read-only list (democratic tab) -->
-                <div v-else-if="activeTab === 'democratic' && picklistStore.democraticList.length > 0">
-                    <div v-for="(team, index) in picklistStore.activeOrderedTeams" :key="team.team_number"
-                        class="picklist-row" :class="{ 'picklist-row--expanded': expandedTeam === team.team_number }"
-                        :id="`picklist-team-demo-${team.team_number}`">
-                        <div class="picklist-row-collapsed" @click="toggleExpand(team.team_number)">
-                            <div class="picklist-rank">{{ index + 1 }}</div>
-                            <div class="picklist-thumb-wrapper">
-                                <img v-if="team.photo_url" :src="team.photo_url" :alt="`Team ${team.team_number} robot`"
-                                    class="picklist-thumb" loading="lazy" />
-                                <div v-else class="picklist-thumb-placeholder">
-                                    <span>🤖</span>
-                                </div>
-                            </div>
-                            <div class="picklist-team-info">
-                                <span class="picklist-team-number">{{ team.team_number }}</span>
-                                <span class="picklist-team-name">{{ team.name }}</span>
-                            </div>
-                            <div class="picklist-rank-stats" @click.stop>
-                                <template v-if="rankStatsFor(team.team_number)">
-                                    <div class="rank-stat" title="Highest (best) rank across personal lists">
-                                        <span class="rank-stat-label">Hi</span>
-                                        <span class="rank-stat-value">{{ formatRankNumber(rankStatsFor(team.team_number).highest) }}</span>
-                                    </div>
-                                    <div class="rank-stat" title="Lowest (worst) rank across personal lists">
-                                        <span class="rank-stat-label">Lo</span>
-                                        <span class="rank-stat-value">{{ formatRankNumber(rankStatsFor(team.team_number).lowest) }}</span>
-                                    </div>
-                                    <div class="rank-stat" title="Mean rank across personal lists">
-                                        <span class="rank-stat-label">Avg</span>
-                                        <span class="rank-stat-value">{{ formatRankNumber(rankStatsFor(team.team_number).mean) }}</span>
-                                    </div>
-                                    <div class="rank-stat" title="Median rank across personal lists">
-                                        <span class="rank-stat-label">Med</span>
-                                        <span class="rank-stat-value">{{ formatRankNumber(rankStatsFor(team.team_number).median) }}</span>
-                                    </div>
-                                </template>
-                                <span v-else class="picklist-rank-stats-empty">No picks yet</span>
-                            </div>
-                            <div class="picklist-expand-chevron"
-                                :class="{ 'picklist-expand-chevron--open': expandedTeam === team.team_number }">
-                                ›
-                            </div>
+                <!-- Tier-grouped sections -->
+                <div v-else class="tier-sections">
+                    <div v-for="group in TIER_GROUPS" :key="group" class="tier-section">
+                        <div class="tier-section-header" :class="`tier-section-header--${group}`">
+                            <span class="tier-section-name">{{ tierGroupLabel(group) }}</span>
+                            <span class="tier-section-count">{{ (picklistStore.activeSections[group] || []).length }}</span>
                         </div>
 
-                        <transition name="expand">
-                            <div v-if="expandedTeam === team.team_number" class="picklist-row-detail">
-                                <div v-if="expandedLoading" class="picklist-detail-loading">
-                                    <div class="picklist-spinner picklist-spinner--sm"></div> Loading data…
-                                </div>
-                                <div v-else-if="expandedData" class="picklist-detail-content">
-                                    <div class="picklist-detail-photo" v-if="team.photo_url">
-                                        <img :src="team.photo_url" :alt="`Team ${team.team_number} robot (full)`"
-                                            class="picklist-full-photo" />
-                                    </div>
-                                    <div class="picklist-detail-section" v-if="expandedData.stats.length > 0">
-                                        <h3 class="picklist-detail-heading">Match Stats ({{ expandedData.stats.length }}
-                                            matches)</h3>
-                                        <div class="picklist-stats-grid">
-                                            <div v-for="stat in computeBasicStats(expandedData.stats)" :key="stat.label"
-                                                class="picklist-stat-card">
-                                                <div class="stat-label">{{ stat.label }}</div>
-                                                <div class="stat-avg">{{ stat.avg }}</div>
-                                                <div class="stat-sub">avg &nbsp;|&nbsp; max {{ stat.max }}</div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div v-else class="picklist-no-data">No match data available.</div>
+                        <!-- Editable: draggable within and across tier sections -->
+                        <draggable v-if="isEditable" :list="picklistStore.activeSections[group]" group="picklist"
+                            :item-key="(el) => el" handle=".picklist-drag-handle" animation="200"
+                            ghost-class="picklist-row--ghost" :force-fallback="true" :scroll="false"
+                            class="tier-section-body" @start="onDragStart" @end="onDragEnd" @change="saveList">
+                            <template #item="{ element: teamNumber, index }">
+                                <PicklistRow :row-id="`picklist-team-${teamNumber}`" :team="picklistStore.teamMap[teamNumber]"
+                                    :position="groupRankOffset(group) + index + 1" :show-drag-handle="true" :show-vote-stats="showVoteStats"
+                                    :tier-stats="tierStatsFor(teamNumber)" :show-picked="showPickedCheckbox"
+                                    :is-picked="picklistStore.isTeamPicked(teamNumber)"
+                                    :can-toggle-picked="isLead" :expanded="expandedTeam === teamNumber"
+                                    :expanded-data="expandedData" :expanded-loading="expandedLoading"
+                                    @toggle-expand="toggleExpand(teamNumber)" @toggle-picked="togglePicked(teamNumber)" />
+                            </template>
+                        </draggable>
 
-                                    <div class="picklist-detail-section" v-if="expandedData.comments.length > 0">
-                                        <h3 class="picklist-detail-heading">Scout Comments</h3>
-                                        <ul class="picklist-comments-list">
-                                            <li v-for="(comment, idx) in expandedData.comments" :key="idx"
-                                                class="picklist-comment">
-                                                <div class="comment-meta">
-                                                    <span class="comment-author">{{ comment.author }}</span>
-                                                    <span class="comment-source-badge">{{ comment.source }}</span>
-                                                    <span class="comment-match" v-if="comment.match_number != null">Match
-                                                        {{ comment.match_number }}</span>
-                                                </div>
-                                                <p class="comment-text">{{ comment.comment }}</p>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                        </transition>
+                        <!-- Read-only (democratic tab) -->
+                        <div v-else class="tier-section-body tier-section-body--static">
+                            <PicklistRow v-for="(teamNumber, index) in picklistStore.activeSections[group]" :key="teamNumber"
+                                :row-id="`picklist-team-demo-${teamNumber}`" :team="picklistStore.teamMap[teamNumber]"
+                                :position="groupRankOffset(group) + index + 1" :show-drag-handle="false" :show-vote-stats="showVoteStats"
+                                :tier-stats="tierStatsFor(teamNumber)" :show-picked="showPickedCheckbox"
+                                :is-picked="picklistStore.isTeamPicked(teamNumber)"
+                                :can-toggle-picked="isLead" :expanded="expandedTeam === teamNumber"
+                                :expanded-data="expandedData" :expanded-loading="expandedLoading"
+                                @toggle-expand="toggleExpand(teamNumber)" @toggle-picked="togglePicked(teamNumber)" />
+                        </div>
+
+                        <div v-if="(picklistStore.activeSections[group] || []).length === 0" class="tier-section-empty">
+                            {{ isEditable ? 'Drag teams here' : 'No teams in this tier' }}
+                        </div>
                     </div>
                 </div>
             </div>
@@ -632,12 +484,6 @@ function formatRankNumber(n: number) {
     animation: spin 0.8s linear infinite;
 }
 
-.picklist-spinner--sm {
-    width: 20px;
-    height: 20px;
-    border-width: 2px;
-}
-
 @keyframes spin {
     to {
         transform: rotate(360deg);
@@ -724,339 +570,89 @@ function formatRankNumber(n: number) {
     cursor: not-allowed;
 }
 
-/* ── Row ── */
-.picklist-list-wrapper {
-    display: flex;
-    flex-direction: column;
-}
-
-.picklist-row {
-    background: var(--tile-background-color);
-    border-radius: 12px;
-    margin-bottom: 8px;
-    overflow: hidden;
-    box-shadow:
-        inset 0 0 0.5px 1px hsla(0, 0%, 100%, 0.07),
-        0 1px 4px hsla(230, 13%, 9%, 0.07),
-        0 2px 10px hsla(230, 13%, 9%, 0.06);
-    transition: box-shadow 0.2s ease;
-}
-
-.picklist-row:hover {
-    box-shadow:
-        inset 0 0 0.5px 1px hsla(0, 0%, 100%, 0.1),
-        0 2px 8px hsla(230, 13%, 9%, 0.12),
-        0 4px 16px hsla(230, 13%, 9%, 0.1);
-}
-
-.picklist-row--expanded {
-    box-shadow:
-        0 0 0 2px #b05703,
-        0 4px 20px hsla(230, 13%, 9%, 0.14);
-}
-
-.picklist-row--ghost {
-    opacity: 0.45;
-}
-
-/* Collapsed row layout */
-.picklist-row-collapsed {
-    display: flex;
-    align-items: center;
-    padding: 10px 14px;
-    cursor: pointer;
-    gap: 12px;
-    min-height: 68px;
-    user-select: none;
-}
-
-.picklist-drag-handle {
-    color: rgba(128, 128, 128, 0.5);
-    cursor: grab;
-    font-size: 20px;
-    padding: 4px;
-    flex-shrink: 0;
-    transition: color 0.15s;
-    line-height: 1;
-}
-
-.picklist-drag-handle:hover {
-    color: #b05703;
-}
-
-.picklist-rank {
-    font-size: 18px;
-    font-weight: 700;
-    color: #b05703;
-    min-width: 30px;
-    text-align: center;
-    flex-shrink: 0;
-}
-
-.picklist-thumb-wrapper {
-    width: 52px;
-    height: 52px;
-    border-radius: 8px;
-    overflow: hidden;
-    flex-shrink: 0;
-    background: rgba(128, 128, 128, 0.1);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.picklist-thumb {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-}
-
-.picklist-thumb-placeholder {
-    font-size: 26px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-}
-
-.picklist-team-info {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    min-width: 0;
-}
-
-.picklist-team-number {
-    font-size: 16px;
-    font-weight: 700;
-    color: var(--primary-text-color);
-    line-height: 1.2;
-}
-
-.picklist-team-name {
-    font-size: 13px;
-    color: rgba(128, 128, 128, 0.8);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.picklist-expand-chevron {
-    font-size: 24px;
-    font-weight: 300;
-    color: rgba(128, 128, 128, 0.5);
-    transition: transform 0.22s ease, color 0.15s ease;
-    flex-shrink: 0;
-    line-height: 1;
-    padding-left: 4px;
-}
-
-/* ── Rank stats (Democratic / Team rows) ── */
-.picklist-rank-stats {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    flex-shrink: 0;
-    cursor: default;
-}
-
-.rank-stat {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    min-width: 28px;
-}
-
-.rank-stat-label {
-    font-size: 9px;
-    font-weight: 600;
-    color: rgba(128, 128, 128, 0.7);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    line-height: 1.2;
-}
-
-.rank-stat-value {
-    font-size: 14px;
-    font-weight: 700;
-    color: var(--primary-text-color);
-    line-height: 1.2;
-}
-
-.picklist-rank-stats-empty {
-    font-size: 11px;
-    color: rgba(128, 128, 128, 0.6);
-    font-style: italic;
-    white-space: nowrap;
-}
-
-.picklist-expand-chevron--open {
-    transform: rotate(90deg);
-    color: #b05703;
-}
-
-/* ── Detail section ── */
-.picklist-row-detail {
-    border-top: 1px solid rgba(128, 128, 128, 0.15);
-    padding: 16px 14px 20px;
-    overflow: hidden;
-}
-
-.picklist-detail-loading {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    font-size: 13px;
-    color: rgba(128, 128, 128, 0.7);
-    padding: 8px 0;
-}
-
-.picklist-detail-content {
+/* ── Tier sections ── */
+.tier-sections {
     display: flex;
     flex-direction: column;
     gap: 18px;
 }
 
-.picklist-detail-photo {
-    display: flex;
-    justify-content: center;
-}
-
-.picklist-full-photo {
-    max-width: 340px;
-    width: 100%;
-    border-radius: 10px;
-    object-fit: cover;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
-}
-
-.picklist-detail-heading {
-    font-size: 14px;
-    font-weight: 700;
-    color: #b05703;
-    margin-bottom: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-}
-
-.picklist-detail-section {
+.tier-section {
     display: flex;
     flex-direction: column;
 }
 
-/* Stats grid */
-.picklist-stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-    gap: 10px;
-}
-
-.picklist-stat-card {
-    background: rgba(176, 87, 3, 0.08);
-    border: 1px solid rgba(176, 87, 3, 0.2);
-    border-radius: 10px;
-    padding: 10px 12px;
-    text-align: center;
-}
-
-.stat-label {
-    font-size: 11px;
-    color: rgba(128, 128, 128, 0.75);
-    margin-bottom: 4px;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-}
-
-.stat-avg {
-    font-size: 22px;
-    font-weight: 700;
-    color: #b05703;
-    line-height: 1.1;
-}
-
-.stat-sub {
-    font-size: 10px;
-    color: rgba(128, 128, 128, 0.6);
-    margin-top: 2px;
-}
-
-/* Comments */
-.picklist-comments-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.picklist-comment {
-    border: 1px solid rgba(128, 128, 128, 0.2);
-    border-radius: 10px;
-    padding: 10px 14px;
-}
-
-.comment-meta {
+.tier-section-header {
     display: flex;
     align-items: center;
     gap: 8px;
-    margin-bottom: 6px;
-    flex-wrap: wrap;
+    padding: 4px 10px;
+    margin-bottom: 8px;
+    border-left: 4px solid rgba(128, 128, 128, 0.4);
 }
 
-.comment-author {
-    font-weight: 700;
-    font-size: 13px;
+.tier-section-name {
+    font-size: 15px;
+    font-weight: 800;
+    letter-spacing: 0.04em;
     color: var(--primary-text-color);
 }
 
-.comment-source-badge {
-    font-size: 10px;
+.tier-section-count {
+    font-size: 12px;
     font-weight: 600;
-    padding: 2px 7px;
+    color: rgba(128, 128, 128, 0.7);
+    background: rgba(128, 128, 128, 0.12);
     border-radius: 20px;
-    background: rgba(176, 87, 3, 0.15);
-    color: #b05703;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
+    padding: 1px 8px;
 }
 
-.comment-match {
-    font-size: 11px;
-    color: rgba(128, 128, 128, 0.6);
-    margin-left: auto;
+.tier-section-header--S {
+    border-left-color: #d4a017;
 }
 
-.comment-text {
-    font-size: 13px;
-    color: var(--primary-text-color);
-    line-height: 1.55;
-    margin: 0;
+.tier-section-header--A {
+    border-left-color: #3a9e3a;
 }
 
-.picklist-no-data {
-    font-size: 13px;
-    color: rgba(128, 128, 128, 0.6);
+.tier-section-header--B {
+    border-left-color: #3a78c8;
+}
+
+.tier-section-header--C {
+    border-left-color: #8c64c8;
+}
+
+.tier-section-header--D {
+    border-left-color: #b05703;
+}
+
+.tier-section-header--DNP {
+    border-left-color: #c83c3c;
+}
+
+.tier-section-header--Unranked {
+    border-left-color: rgba(128, 128, 128, 0.4);
+}
+
+.tier-section-body {
+    display: flex;
+    flex-direction: column;
+    min-height: 50px;
+}
+
+.tier-section-empty {
+    font-size: 12px;
+    color: rgba(128, 128, 128, 0.55);
     font-style: italic;
-    padding: 4px 0;
+    text-align: center;
+    padding: 10px;
+    border: 1.5px dashed rgba(128, 128, 128, 0.25);
+    border-radius: 10px;
+    margin-top: -4px;
 }
 
 /* ── Transitions ── */
-.expand-enter-active,
-.expand-leave-active {
-    transition: max-height 0.28s ease, opacity 0.22s ease;
-    max-height: 1200px;
-    overflow: hidden;
-}
-
-.expand-enter-from,
-.expand-leave-to {
-    max-height: 0;
-    opacity: 0;
-}
-
 .fade-enter-active,
 .fade-leave-active {
     transition: opacity 0.3s ease;

--- a/supabase/database/schemas/prod.sql
+++ b/supabase/database/schemas/prod.sql
@@ -256,6 +256,8 @@ CREATE TABLE IF NOT EXISTS "public"."PickList" (
     "team_numbers" integer[] DEFAULT '{}'::integer[] NOT NULL,
     "created_at" timestamp with time zone DEFAULT "now"(),
     "updated_at" timestamp with time zone DEFAULT "now"(),
+    "team_tiers" jsonb DEFAULT '{}'::jsonb NOT NULL,
+    "picked_team_numbers" integer[] DEFAULT '{}'::integer[] NOT NULL,
     CONSTRAINT "PickList_type_check" CHECK (("type" = ANY (ARRAY['personal'::"text", 'team'::"text"])))
 );
 

--- a/supabase/migrations/20260722120000_add_picklist_tiers_and_picked.sql
+++ b/supabase/migrations/20260722120000_add_picklist_tiers_and_picked.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public."PickList" ADD COLUMN team_tiers jsonb DEFAULT '{}'::jsonb NOT NULL;
+ALTER TABLE public."PickList" ADD COLUMN picked_team_numbers integer[] DEFAULT '{}'::integer[] NOT NULL;


### PR DESCRIPTION
Replaces numeric rank ordering with S/A/B/C/D/DNP tier sections (plus an Unranked pool) across the Personal, Democratic, and Team tabs, and adds a lead-only "picked" checkbox on the Team tab that grays out drafted teams. Democratic aggregation now averages tiers/ranks across scouts who actually tiered a team, so leaving a team unranked never counts against it.