### PR TITLE
Redesign match scouting for Chezy Champs: compact multi-team form, new toggles, watchlist

### DIFF
--- a/src/components/MatchTeamRow.vue
+++ b/src/components/MatchTeamRow.vue
@@ -1,0 +1,223 @@
+<script setup lang="ts">
+// @ts-nocheck
+import FormSection from '@/components/FormSection.vue';
+
+const props = defineProps({
+    slotLabel: { default: '' },
+    teamNumber: { default: null },
+    teamName: { default: '' },
+    allianceColor: { default: 'red' },
+    schema: { default: () => [] },
+    expanded: { default: false },
+    dirty: { default: false },
+    included: { default: true },
+    watched: { default: false },
+    formInvalid: { default: false }
+});
+
+const emit = defineEmits(['toggle-expand', 'toggle-included', 'form-update']);
+
+function findPostmatchComponent(key) {
+    return props.schema?.find((s) => s.key === 'postmatch')?.components?.find((c) => c.key === key);
+}
+</script>
+
+<template>
+    <div class="match-row" :class="{
+        'match-row--empty': !dirty,
+        'match-row--watched': watched,
+        'match-row--invalid': formInvalid,
+        'match-row--expanded': expanded
+    }">
+        <div class="match-row-collapsed" @click="emit('toggle-expand')">
+            <span v-if="watched" class="match-row-star" title="On the watchlist">★</span>
+            <div class="match-row-slot" :class="`match-row-slot--${allianceColor}`">{{ slotLabel }}</div>
+            <div class="match-row-team-info">
+                <span class="match-row-team-number">{{ teamNumber ?? '—' }}</span>
+                <span class="match-row-team-name">{{ teamName }}</span>
+            </div>
+            <span v-if="!dirty" class="match-row-empty-badge">No data yet</span>
+            <label class="match-row-include-check" @click.stop title="Include this team in submission">
+                <input type="checkbox" :checked="included" @change="emit('toggle-included')" />
+            </label>
+            <div class="match-row-chevron" :class="{ 'match-row-chevron--open': expanded }">›</div>
+        </div>
+
+        <transition name="match-row-expand">
+            <div v-if="expanded" class="match-row-detail">
+                <FormSection section-key="prematch" name="Pre-match"
+                    :components="schema.find(s => s.key === 'prematch')?.components ?? []"
+                    :color="allianceColor" @form-update="emit('form-update')">
+                </FormSection>
+                <FormSection section-key="auto" name="Auto"
+                    :components="schema.find(s => s.key === 'auto')?.components ?? []"
+                    color="gray" @form-update="emit('form-update')">
+                </FormSection>
+                <FormSection section-key="postmatch" name="Post Match"
+                    :components="(schema.find(s => s.key === 'postmatch')?.components ?? []).filter(c => c.key !== 'defense_impact' || findPostmatchComponent('played_defense')?.value)"
+                    color="gray" @form-update="emit('form-update')">
+                </FormSection>
+            </div>
+        </transition>
+    </div>
+</template>
+
+<style scoped>
+.match-row {
+    background: var(--tile-background-color);
+    border-radius: 12px;
+    margin-bottom: 8px;
+    overflow: hidden;
+    box-shadow:
+        inset 0 0 0.5px 1px hsla(0, 0%, 100%, 0.07),
+        0 1px 4px hsla(230, 13%, 9%, 0.07),
+        0 2px 10px hsla(230, 13%, 9%, 0.06);
+    transition: box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.match-row--expanded {
+    box-shadow:
+        0 0 0 2px #b05703,
+        0 4px 20px hsla(230, 13%, 9%, 0.14);
+}
+
+/* Grayed out until the scout has actually entered data for this team. */
+.match-row--empty {
+    opacity: 0.55;
+}
+
+.match-row--empty .match-row-team-number,
+.match-row--empty .match-row-team-name {
+    filter: grayscale(60%);
+}
+
+/* Watched teams get a yellow border + star, even while grayed out. */
+.match-row--watched {
+    box-shadow:
+        0 0 0 2px #e0b400,
+        0 2px 10px hsla(230, 13%, 9%, 0.06);
+}
+
+.match-row--watched.match-row--expanded {
+    box-shadow:
+        0 0 0 2px #e0b400,
+        0 4px 20px hsla(230, 13%, 9%, 0.14);
+}
+
+.match-row--invalid {
+    box-shadow: 0 0 0 2px red;
+}
+
+.match-row-collapsed {
+    display: flex;
+    align-items: center;
+    padding: 10px 14px;
+    cursor: pointer;
+    gap: 10px;
+    min-height: 56px;
+    user-select: none;
+}
+
+.match-row-star {
+    color: #e0b400;
+    font-size: 18px;
+    flex-shrink: 0;
+    line-height: 1;
+}
+
+.match-row-slot {
+    font-size: 12px;
+    font-weight: 700;
+    padding: 3px 8px;
+    border-radius: 6px;
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
+.match-row-slot--red {
+    background: rgba(255, 0, 0, 0.15);
+    color: #d32f2f;
+}
+
+.match-row-slot--blue {
+    background: rgba(0, 0, 255, 0.15);
+    color: #1a5fd3;
+}
+
+.match-row-team-info {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+}
+
+.match-row-team-number {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--primary-text-color);
+    line-height: 1.2;
+}
+
+.match-row-team-name {
+    font-size: 12px;
+    color: rgba(128, 128, 128, 0.8);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.match-row-empty-badge {
+    font-size: 11px;
+    color: rgba(128, 128, 128, 0.7);
+    font-style: italic;
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
+.match-row-include-check {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    cursor: pointer;
+}
+
+.match-row-include-check input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: #b05703;
+    cursor: pointer;
+}
+
+.match-row-chevron {
+    font-size: 22px;
+    font-weight: 300;
+    color: rgba(128, 128, 128, 0.5);
+    transition: transform 0.22s ease, color 0.15s ease;
+    flex-shrink: 0;
+    line-height: 1;
+}
+
+.match-row-chevron--open {
+    transform: rotate(90deg);
+    color: #b05703;
+}
+
+.match-row-detail {
+    border-top: 1px solid rgba(128, 128, 128, 0.15);
+    padding: 6px 10px 14px;
+    overflow: hidden;
+}
+
+.match-row-expand-enter-active,
+.match-row-expand-leave-active {
+    transition: max-height 0.28s ease, opacity 0.22s ease;
+    max-height: 1200px;
+    overflow: hidden;
+}
+
+.match-row-expand-enter-from,
+.match-row-expand-leave-to {
+    max-height: 0;
+    opacity: 0;
+}
+</style>

--- a/src/components/PicklistRow.vue
+++ b/src/components/PicklistRow.vue
@@ -13,12 +13,14 @@ defineProps<{
     showPicked: boolean;
     isPicked: boolean;
     canTogglePicked: boolean;
+    watched: boolean;
+    canToggleWatch: boolean;
     expanded: boolean;
     expandedData: { stats: unknown[]; comments: unknown[] } | null;
     expandedLoading: boolean;
 }>();
 
-const emit = defineEmits(['toggle-expand', 'toggle-picked']);
+const emit = defineEmits(['toggle-expand', 'toggle-picked', 'toggle-watch']);
 
 function computeBasicStats(matchData: unknown[]) {
     if (!matchData.length) return [];
@@ -88,6 +90,12 @@ function formatAvgRank(avgRank: number) {
                 <input type="checkbox" :checked="isPicked" :disabled="!canTogglePicked"
                     @change="emit('toggle-picked')" />
             </label>
+            <button v-if="watched || canToggleWatch" type="button" class="picklist-watch-star"
+                :class="{ 'picklist-watch-star--active': watched, 'picklist-watch-star--readonly': !canToggleWatch }"
+                :disabled="!canToggleWatch" @click.stop="canToggleWatch && emit('toggle-watch')"
+                :title="canToggleWatch ? (watched ? 'Remove from watchlist' : 'Add to watchlist') : 'On the watchlist'">
+                ★
+            </button>
             <div class="picklist-expand-chevron" :class="{ 'picklist-expand-chevron--open': expanded }">
                 ›
             </div>
@@ -343,6 +351,33 @@ function formatAvgRank(avgRank: number) {
 .picklist-picked-check input[type="checkbox"]:disabled {
     cursor: default;
     opacity: 0.6;
+}
+
+/* ── Watchlist star ── */
+.picklist-watch-star {
+    background: none;
+    border: none;
+    padding: 2px;
+    margin-left: 2px;
+    font-size: 20px;
+    line-height: 1;
+    flex-shrink: 0;
+    cursor: pointer;
+    color: rgba(128, 128, 128, 0.35);
+    transition: color 0.15s ease, transform 0.1s ease;
+}
+
+.picklist-watch-star:not(:disabled):hover {
+    color: #e0b400;
+    transform: scale(1.1);
+}
+
+.picklist-watch-star--active {
+    color: #e0b400;
+}
+
+.picklist-watch-star--readonly {
+    cursor: default;
 }
 
 /* ── Detail section ── */

--- a/src/lib/2026/match-scouting-form.ts
+++ b/src/lib/2026/match-scouting-form.ts
@@ -1,119 +1,168 @@
 // @ts-nocheck
 
-import { getTeamInputElement } from "@/lib/data-submission";
+// Per-team fields for the "Pre-match" section of a match-scouting row.
+// team_number, match_number, and alliance are no longer editable form
+// components here — in the compact multi-team match form they're derived
+// from the match schedule slot and set directly on the parsed submission.
+export function getMatchPrematchTeamFields() {
+    return [
+        {
+            key: "noshow",
+            label: "No Show",
+            type: "switch",
+            options: {},
+            defaultValue: false,
+            value: false,
+            preserveAfterSubmit: false,
+            incrementAfterSubmit: false,
+            required: false,
+            error: false
+        },
+    ];
+}
 
-export async function getMatchScoutSchema() {
-    const teamInputElement = await getTeamInputElement();
+// Per-team fields for the "Auto" section of a match-scouting row.
+export function getMatchAutoFields() {
+    return [
+        {
+            key: "failed",
+            label: "Did auto fail?",
+            type: "switch",
+            options: {},
+            defaultValue: false,
+            value: false,
+            preserveAfterSubmit: false,
+            incrementAfterSubmit: false,
+            required: false,
+            error: false
+        },
+    ];
+}
 
+// Per-team fields for the "Post Match" section of a match-scouting row.
+export function getMatchPostmatchFields() {
+    return [
+        {
+            key: "cards",
+            label: "Cards?",
+            type: "dropdown",
+            options: {
+                choices: [
+                    { key: "none", text: "No Card" },
+                    { key: "yellow", text: "Yellow Card" },
+                    { key: "red", text: "Red Card" },
+                ]
+            },
+            defaultValue: 0,
+            value: 0,
+            preserveAfterSubmit: false,
+            incrementAfterSubmit: false,
+            required: false,
+            error: false
+        },
+        {
+            key: "died",
+            label: "Died?",
+            type: "switch",
+            options: {},
+            defaultValue: false,
+            value: false,
+            preserveAfterSubmit: false,
+            incrementAfterSubmit: false,
+            required: false,
+            error: false
+        },
+        {
+            key: "broke",
+            label: "Broke?",
+            type: "switch",
+            options: {},
+            defaultValue: false,
+            value: false,
+            preserveAfterSubmit: false,
+            incrementAfterSubmit: false,
+            required: false,
+            error: false
+        },
+        {
+            key: "beached",
+            label: "Beached?",
+            type: "switch",
+            options: {},
+            defaultValue: false,
+            value: false,
+            preserveAfterSubmit: false,
+            incrementAfterSubmit: false,
+            required: false,
+            error: false
+        },
+        {
+            key: "played_defense",
+            label: "Played Defense?",
+            type: "switch",
+            options: {},
+            defaultValue: false,
+            value: false,
+            preserveAfterSubmit: false,
+            incrementAfterSubmit: false,
+            required: false,
+            error: false
+        },
+        // Only shown (see MatchTeamRow.vue) when played_defense is true. Kept
+        // required:false always, even though it's conditionally displayed, so
+        // a hidden field can never block validateForm() from passing.
+        {
+            key: "defense_impact",
+            label: "Defense Impact",
+            type: "dropdown",
+            options: {
+                choices: [
+                    { key: "none", text: "Select impact..." },
+                    { key: "good", text: "Good" },
+                    { key: "minimal", text: "Minimal" },
+                    { key: "ineffective", text: "Ineffective" },
+                ]
+            },
+            defaultValue: 0,
+            value: 0,
+            preserveAfterSubmit: false,
+            incrementAfterSubmit: false,
+            required: false,
+            error: false
+        },
+        {
+            key: "comments",
+            label: "Comments",
+            type: "textarea",
+            options: {},
+            defaultValue: "",
+            value: "",
+            preserveAfterSubmit: false,
+            incrementAfterSubmit: false,
+            required: true,
+            error: false
+        },
+    ];
+}
+
+// The full {key, name, components} section shape for one team's row —
+// matches what FormSection/validateForm/parseScoutData already expect.
+export function buildTeamRowSchema() {
     return [
         {
             key: "prematch",
             name: "Pre-match",
-            components: [
-                {
-                    key: "match_number",
-                    label: "Match Number",
-                    type: "number",
-                    options: {},
-                    defaultValue: null,
-                    value: null,
-                    preserveAfterSubmit: false,
-                    incrementAfterSubmit: true,
-                    required: true,
-                    error: false
-                },
-                {
-                    key: "manual_entry",
-                    label: "Manual Team Entry",
-                    type: "switch",
-                    options: {},
-                    defaultValue: false,
-                    value: false,
-                    // Preserved across submissions: a scout who needs manual mode
-                    // (e.g. the schedule isn't synced yet) likely needs it for the
-                    // whole event, not just one match.
-                    preserveAfterSubmit: true,
-                    incrementAfterSubmit: false,
-                    required: false,
-                    error: false
-                },
-                teamInputElement,
-                {
-                    key: "alliance",
-                    label: "Alliance",
-                    type: "optionswitch",
-                    options: {
-                        unselected: "Red",
-                        selected: "Blue",
-                    },
-                    defaultValue: false,
-                    value: false,
-                    preserveAfterSubmit: false,
-                    incrementAfterSubmit: false,
-                    required: false,
-                    error: false
-                },
-                {
-                    key: "noshow",
-                    label: "No Show",
-                    type: "switch",
-                    options: {},
-                    defaultValue: false,
-                    value: false,
-                    preserveAfterSubmit: false,
-                    incrementAfterSubmit: false,
-                    required: false,
-                    error: false
-                },
-            ]
+            components: getMatchPrematchTeamFields()
+        },
+        {
+            key: "auto",
+            name: "Auto",
+            components: getMatchAutoFields()
         },
         {
             key: "postmatch",
             name: "Post Match",
-            components: [
-                {
-                    key: "cards",
-                    label: "Cards?",
-                    type: "dropdown",
-                    options: {
-                        choices: [
-                            { key: "none", text: "No Card" },
-                            { key: "yellow", text: "Yellow Card" },
-                            { key: "red", text: "Red Card" },
-                        ]
-                    },
-                    defaultValue: 0,
-                    value: 0,
-                    preserveAfterSubmit: false,
-                    incrementAfterSubmit: false,
-                    required: false,
-                    error: false
-                },
-                {
-                    key: "died",
-                    label: "Died?",
-                    type: "switch",
-                    options: {},
-                    defaultValue: false,
-                    value: false,
-                    preserveAfterSubmit: false,
-                    incrementAfterSubmit: false,
-                    required: false,
-                    error: false
-                },
-                {
-                    key: "comments",
-                    label: "Comments",
-                    type: "textarea",
-                    options: {},
-                    defaultValue: "",
-                    value: "",
-                    preserveAfterSubmit: false,
-                    incrementAfterSubmit: false,
-                    required: true,
-                    error: false
-                },
-            ]
+            components: getMatchPostmatchFields()
         }
     ];
-} 
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,6 +18,7 @@ export const userTable = "User";
 export const pickListTable = "PickList";
 export const userProfileTable = "UserProfile";
 export const autoPathTable = "AutoPath";
+export const watchlistTable = "Watchlist";
 
 // Picklist types
 export const pickListTypePersonal = "personal";

--- a/src/lib/watchlist-query.ts
+++ b/src/lib/watchlist-query.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+
+import { supabase } from '@/lib/supabase-client';
+import { watchlistTable } from '@/lib/constants';
+
+/**
+ * Fetch the set of team numbers currently on the watchlist for an event.
+ */
+export async function fetchWatchlist(eventId: string): Promise<number[]> {
+    const { data, error } = await supabase
+        .from(watchlistTable)
+        .select('team_number')
+        .eq('event_id', eventId);
+
+    if (error) {
+        console.error('fetchWatchlist error:', error);
+        return [];
+    }
+
+    return (data ?? []).map((row) => row.team_number);
+}
+
+/**
+ * Add a team to the event's watchlist. Returns the error object or null on success.
+ */
+export async function addToWatchlist(eventId: string, teamNumber: number) {
+    const { error } = await supabase
+        .from(watchlistTable)
+        .insert({ event_id: eventId, team_number: teamNumber });
+
+    return error;
+}
+
+/**
+ * Remove a team from the event's watchlist. Returns the error object or null on success.
+ */
+export async function removeFromWatchlist(eventId: string, teamNumber: number) {
+    const { error } = await supabase
+        .from(watchlistTable)
+        .delete()
+        .eq('event_id', eventId)
+        .eq('team_number', teamNumber);
+
+    return error;
+}

--- a/src/stores/watchlist-store.ts
+++ b/src/stores/watchlist-store.ts
@@ -1,0 +1,53 @@
+// @ts-nocheck
+
+import { defineStore } from 'pinia';
+import { fetchWatchlist, addToWatchlist, removeFromWatchlist } from '@/lib/watchlist-query';
+
+export const useWatchlistStore = defineStore('watchlist', {
+    state() {
+        return {
+            eventId: null as string | null,
+            watchedTeamNumbers: [] as number[],
+            loaded: false
+        };
+    },
+    getters: {
+        isWatched(state) {
+            return (teamNumber: number) => state.watchedTeamNumbers.includes(Number(teamNumber));
+        }
+    },
+    actions: {
+        async loadWatchlist(eventId: string) {
+            this.eventId = eventId;
+            this.loaded = false;
+            this.watchedTeamNumbers = await fetchWatchlist(eventId);
+            this.loaded = true;
+        },
+
+        // Optimistically flips the local state, then reverts if the write fails.
+        // Returns the error object or null on success.
+        async toggleWatch(eventId: string, teamNumber: number) {
+            const num = Number(teamNumber);
+            const wasWatched = this.watchedTeamNumbers.includes(num);
+
+            if (wasWatched) {
+                this.watchedTeamNumbers = this.watchedTeamNumbers.filter((n) => n !== num);
+            } else {
+                this.watchedTeamNumbers = [...this.watchedTeamNumbers, num];
+            }
+
+            const error = wasWatched
+                ? await removeFromWatchlist(eventId, num)
+                : await addToWatchlist(eventId, num);
+
+            if (error) {
+                // Revert the optimistic update.
+                this.watchedTeamNumbers = wasWatched
+                    ? [...this.watchedTeamNumbers, num]
+                    : this.watchedTeamNumbers.filter((n) => n !== num);
+            }
+
+            return error;
+        }
+    }
+});

--- a/src/views/MatchScoutView.vue
+++ b/src/views/MatchScoutView.vue
@@ -1,14 +1,17 @@
 <script setup lang="ts">
 // @ts-nocheck
-import FormSection from "@/components/FormSection.vue";
+import MatchTeamRow from "@/components/MatchTeamRow.vue";
+import Dropdown from "@/components/Dropdown.vue";
+import NumberInput from "@/components/Number.vue";
+import Switch from "@/components/Switch.vue";
 
 import { matchScoutTable } from "@/lib/constants";
-import { getMatchScoutSchema } from "@/lib/2026/match-scouting-form";
-import { validateForm, parseScoutData, submitScoutData } from "@/lib/data-submission";
+import { buildTeamRowSchema } from "@/lib/2026/match-scouting-form";
+import { validateForm, parseScoutData, submitScoutData, getTeamInputElement } from "@/lib/data-submission";
 import { queryMatchTeams } from "@/lib/data-query";
-import { buildMatchTeamChoices } from "@/lib/match-schedule";
 import { useEventStore } from "@/stores/event-store";
 import { useOfflineQueueStore } from "@/stores/offline-queue-store";
+import { useWatchlistStore } from "@/stores/watchlist-store";
 
 import "@material/web/button/filled-button";
 </script>
@@ -17,14 +20,48 @@ import "@material/web/button/filled-button";
     <div class="main-content">
         <h1>Match Scouting</h1>
 
-        <form v-if="formLoaded">
-            <FormSection v-for="section in scoutForm" :section-key="section.key" :name="section.name"
-                :components="section.key === 'prematch' ? visiblePrematchComponents : section.components"
-                :color="getAllianceColor" @form-update="onFormUpdate"></FormSection>
-        </form>
+        <div v-if="formLoaded" class="data-tile">
+            <div class="match-controls">
+                <div class="match-control">
+                    Match Number:
+                    <NumberInput :model-value="matchNumber" @update:modelValue="onMatchNumberChange" label="">
+                    </NumberInput>
+                </div>
+                <div class="match-control">
+                    Manual Team Entry:
+                    <Switch :model-value="manualEntry" @update:modelValue="onManualEntryChange"></Switch>
+                </div>
+            </div>
+            <p v-if="scheduleLookupFailed && !manualEntry">No qualification schedule found for that match — assign
+                teams manually below.</p>
+        </div>
+
+        <div v-if="formLoaded && showManualPicker" class="data-tile manual-assign-tile">
+            <h3>Team Assignment</h3>
+            <div class="manual-assign-grid">
+                <div v-for="(slot, idx) in slots" :key="slot.key" class="manual-assign-row">
+                    <span class="manual-assign-label" :class="`manual-assign-label--${slot.allianceColor}`">{{ slot.label
+                        }}</span>
+                    <Dropdown :choices="allTeamChoices" :model-value="manualTeamIndices[idx]"
+                        @update:modelValue="onManualTeamChange(idx, $event)"></Dropdown>
+                </div>
+            </div>
+        </div>
+
+        <div v-if="formLoaded" class="match-rows">
+            <MatchTeamRow v-for="(slot, idx) in slots" :key="slot.key + '-' + (slot.teamNumber ?? 'unassigned')"
+                :slot-label="slot.label" :team-number="slot.teamNumber"
+                :team-name="slot.teamNumber ? (teamNameByNumber[slot.teamNumber] ?? '') : ''"
+                :alliance-color="slot.allianceColor" :schema="rows[idx].schema" :expanded="rows[idx].expanded"
+                :dirty="rows[idx].dirty" :included="rows[idx].included"
+                :watched="slot.teamNumber ? watchlistStore.isWatched(slot.teamNumber) : false"
+                :form-invalid="rows[idx].formInvalid" @toggle-expand="toggleExpand(idx)"
+                @toggle-included="toggleIncluded(idx)" @form-update="onRowFormUpdate(idx)">
+            </MatchTeamRow>
+        </div>
 
         <div class="data-tile error-tile" v-if="formInvalid">
-            <h1>^^^ Form is invalid. Please check the form for errors ^^^</h1>
+            <h1>^^^ Form is invalid. Please check the highlighted teams for errors ^^^</h1>
         </div>
         <div class="data-tile success-tile" v-if="submitSuccess">
             <h1>Submitted successfully!</h1>
@@ -34,57 +71,72 @@ import "@material/web/button/filled-button";
         </div>
 
         <div class="data-tile notification-tile" v-if="queuedOffline">
-            <h1>Couldn't submit — saved locally</h1>
-            <p>This entry has been queued and will sync automatically once you're back online. You can keep
+            <h1>Couldn't submit some teams — saved locally</h1>
+            <p>Those entries have been queued and will sync automatically once you're back online. You can keep
                 scouting in the meantime.</p>
         </div>
 
         <div class="button-container" v-if="formLoaded && !isSubmitting">
-            <!-- Fully reset the form if the reset button is clicked -->
-            <md-filled-button v-on:click="resetFormData(false)" class="reset-button">RESET</md-filled-button>
+            <md-filled-button v-on:click="resetMatch" class="reset-button">RESET</md-filled-button>
 
-            <md-filled-button v-on:click="submitForm" class="submit-button">SUBMIT</md-filled-button>
+            <md-filled-button v-on:click="submitForm" class="submit-button" :disabled="!hasDirtyIncludedRow">
+                SUBMIT
+            </md-filled-button>
         </div>
     </div>
 </template>
 
 <script lang="ts">
+// Slot order/labels/alliance are fixed by position — red1-3 are always Red,
+// blue1-3 are always Blue — unlike the old single-team form where alliance
+// was a scout-entered switch.
+const SLOT_DEFS = [
+    { key: "red1", label: "Red 1", allianceColor: "red" },
+    { key: "red2", label: "Red 2", allianceColor: "red" },
+    { key: "red3", label: "Red 3", allianceColor: "red" },
+    { key: "blue1", label: "Blue 1", allianceColor: "blue" },
+    { key: "blue2", label: "Blue 2", allianceColor: "blue" },
+    { key: "blue3", label: "Blue 3", allianceColor: "blue" },
+];
+
 export default {
     data() {
         return {
             eventStore: null,
             queueStore: null,
+            watchlistStore: null,
             formLoaded: false,
-            scoutForm: null,
-            // Track data submission separately from the act of submitting, so it can
-            // be queued locally if the submission fails.
+            matchNumber: null,
+            manualEntry: false,
+            scheduleLookupFailed: false,
+            allTeamChoices: [],
+            teamNameByNumber: {},
+            slots: SLOT_DEFS.map((def) => ({ ...def, teamNumber: null })),
+            manualTeamIndices: [0, 0, 0, 0, 0, 0],
+            rows: SLOT_DEFS.map(() => this.buildRow()),
+            lastMatchSyncKey: null,
             submitData: {},
             queuedOffline: false,
             submitSuccess: false,
             formInvalid: false,
             isSubmitting: false,
             resetSuccess: false,
-            // Full team_number choices for the event, as loaded at schema time —
-            // restored whenever manual entry is on or the schedule lookup misses.
-            allTeamChoices: [],
-            teamNameByNumber: {},
-            // True once the team_number dropdown is showing schedule-derived
-            // choices for the current match (rather than the full team list) —
-            // drives hiding the now-redundant Alliance field.
-            autoTeamsApplied: false,
-            // `${match_number}|${manual_entry}` for the last schedule lookup, so
-            // unrelated field edits (comments, cards, etc.) don't re-trigger a
-            // lookup and reset the scout's team selection.
-            lastTeamSyncKey: null
         }
     },
     methods: {
+        buildRow() {
+            return {
+                schema: buildTeamRowSchema(),
+                expanded: false,
+                dirty: false,
+                included: true,
+                formInvalid: false
+            };
+        },
         async loadScoutForm() {
             this.formLoaded = false;
-            this.scoutForm = await getMatchScoutSchema();
-            this.formLoaded = true;
 
-            const teamComp = this.findPrematchComponent('team_number');
+            const teamComp = await getTeamInputElement();
             this.allTeamChoices = teamComp?.options?.choices ?? [];
             this.teamNameByNumber = {};
             this.allTeamChoices.forEach((choice) => {
@@ -92,170 +144,164 @@ export default {
                 const [, name] = String(choice.text).split(': ');
                 if (name) this.teamNameByNumber[choice.key] = name;
             });
+
+            this.formLoaded = true;
         },
-        findPrematchComponent(key) {
-            return this.scoutForm?.find(s => s.key === 'prematch')?.components.find(c => c.key === key);
+        toggleExpand(idx) {
+            this.rows[idx].expanded = !this.rows[idx].expanded;
         },
-        onFormUpdate() {
-            this.formValidation();
-            this.syncAutoTeams();
+        toggleIncluded(idx) {
+            this.rows[idx].included = !this.rows[idx].included;
         },
-        async syncAutoTeams() {
-            const matchNumberComp = this.findPrematchComponent('match_number');
-            const manualComp = this.findPrematchComponent('manual_entry');
-            const teamComp = this.findPrematchComponent('team_number');
-            const allianceComp = this.findPrematchComponent('alliance');
-
-            if (!matchNumberComp || !manualComp || !teamComp || !allianceComp) return;
-
-            const syncKey = `${matchNumberComp.value}|${manualComp.value}`;
-            if (syncKey !== this.lastTeamSyncKey) {
-                this.lastTeamSyncKey = syncKey;
-
-                if (manualComp.value || !matchNumberComp.value) {
-                    teamComp.options.choices = this.allTeamChoices;
-                    teamComp.value = 0;
-                    this.autoTeamsApplied = false;
-                } else {
-                    const matchTeams = await queryMatchTeams(this.eventStore.eventId, Number(matchNumberComp.value));
-
-                    if (matchTeams) {
-                        teamComp.options.choices = buildMatchTeamChoices(matchTeams, this.teamNameByNumber);
-                        teamComp.value = 0;
-                        this.autoTeamsApplied = true;
-                    } else {
-                        teamComp.options.choices = this.allTeamChoices;
-                        teamComp.value = 0;
-                        this.autoTeamsApplied = false;
-                    }
-                }
-            }
-
-            // Keep the (hidden, in auto mode) Alliance value in sync with
-            // whichever team the scout picked from the schedule-derived choices.
-            if (this.autoTeamsApplied) {
-                const choice = teamComp.options.choices[teamComp.value];
-                if (choice && typeof choice.isBlue === 'boolean') {
-                    allianceComp.value = choice.isBlue;
-                }
-            }
-        },
-        formValidation() {
-            // The form isn't invalid yet.
-            this.formInvalid = false;
-
-            const { data, valid } = validateForm(this.scoutForm);
-            this.scoutForm = data;
-            this.formInvalid = !valid;
-
-            // reset the submit/reset success flag because the form has changed and has not been submitted yet.
+        onRowFormUpdate(idx) {
+            this.rows[idx].dirty = true;
             this.submitSuccess = false;
             this.resetSuccess = false;
 
-            return valid;
+            // Re-validate this row live so a previously-flagged error clears
+            // as soon as the scout fixes it.
+            if (this.rows[idx].formInvalid) {
+                const { data, valid } = validateForm(this.rows[idx].schema);
+                this.rows[idx].schema = data;
+                this.rows[idx].formInvalid = !valid;
+                if (valid) this.formInvalid = this.rows.some((r) => r.formInvalid);
+            }
         },
-        async submitForm() {
-            // Data submission hasn't failed or succeeded yet...
+        onManualTeamChange(idx, choiceIdx) {
+            this.manualTeamIndices[idx] = choiceIdx;
+            const choice = this.allTeamChoices[choiceIdx];
+            this.setSlotTeam(idx, choice && choice.key !== 'none' ? Number(choice.key) : null);
+        },
+        setSlotTeam(idx, teamNumber) {
+            if (this.slots[idx].teamNumber === teamNumber) return;
+            this.slots[idx].teamNumber = teamNumber;
+            this.rows[idx] = this.buildRow();
+        },
+        async syncMatchTeams() {
+            // Starting a new match context — any leftover submit banner from
+            // the previous match no longer applies.
             this.queuedOffline = false;
             this.submitSuccess = false;
-            this.isSubmitting = true;
             this.resetSuccess = false;
+            this.formInvalid = false;
 
-            // If the form isn't valid, wait for the user to fix it.
-            if (!this.formValidation()) {
+            const syncKey = `${this.matchNumber}|${this.manualEntry}`;
+            if (syncKey === this.lastMatchSyncKey) return;
+            this.lastMatchSyncKey = syncKey;
+
+            if (this.manualEntry || !this.matchNumber) {
+                this.scheduleLookupFailed = false;
+                this.slots.forEach((_, idx) => this.setSlotTeam(idx, null));
+                this.manualTeamIndices = [0, 0, 0, 0, 0, 0];
+                return;
+            }
+
+            const matchTeams = await queryMatchTeams(this.eventStore.eventId, Number(this.matchNumber));
+            if (matchTeams) {
+                this.scheduleLookupFailed = false;
+                SLOT_DEFS.forEach((def, idx) => this.setSlotTeam(idx, matchTeams[def.key] ?? null));
+            } else {
+                this.scheduleLookupFailed = true;
+                this.slots.forEach((_, idx) => this.setSlotTeam(idx, null));
+                this.manualTeamIndices = [0, 0, 0, 0, 0, 0];
+            }
+        },
+        onMatchNumberChange(value) {
+            this.matchNumber = value;
+            this.syncMatchTeams();
+        },
+        onManualEntryChange(value) {
+            this.manualEntry = value;
+            this.syncMatchTeams();
+        },
+        async submitForm() {
+            this.queuedOffline = false;
+            this.submitSuccess = false;
+            this.resetSuccess = false;
+            this.formInvalid = false;
+            this.isSubmitting = true;
+
+            const toSubmit = [];
+            let anyInvalid = false;
+
+            this.rows.forEach((row, idx) => {
+                if (!row.dirty || !row.included) return;
+
+                const { data, valid } = validateForm(row.schema);
+                row.schema = data;
+                row.formInvalid = !valid;
+
+                if (!valid) {
+                    anyInvalid = true;
+                    row.expanded = true;
+                } else {
+                    toSubmit.push(idx);
+                }
+            });
+
+            if (anyInvalid) {
+                this.formInvalid = true;
                 this.isSubmitting = false;
                 return;
             }
 
-            // Parse the data to submit separately from the act of submitting the data to the database in case the connection fails.
-            this.submitData = parseScoutData(this.scoutForm, this.eventStore.eventId)
+            let anyQueuedOffline = false;
 
-            // Attempt to submit the data.
-            const error = await submitScoutData(this.submitData, matchScoutTable);
+            for (const idx of toSubmit) {
+                const row = this.rows[idx];
+                const slot = this.slots[idx];
 
-            // Preserve some things that don't need to be re-entered.
-            this.preserveSingleEntryData();
+                const dbData = parseScoutData(row.schema, this.eventStore.eventId);
+                dbData.prematch_team_number = slot.teamNumber;
+                dbData.prematch_match_number = this.matchNumber;
+                dbData.prematch_alliance = slot.allianceColor === 'blue' ? 'Blue' : 'Red';
 
-            // If the database submission failed, queue it locally for retry instead of blocking the scout.
-            if (error) {
-                console.log(error);
-                this.queueStore.enqueue('scout_data', { table: matchScoutTable, data: this.submitData }, error.message ?? String(error));
+                const error = await submitScoutData(dbData, matchScoutTable);
 
-                // The data is safely queued — let the scout move on to the next match.
-                // (resetFormData() clears queuedOffline, so set it true afterward.)
-                this.resetFormData(true);
-                this.queuedOffline = true;
-                this.submitData = {};
-                this.isSubmitting = false;
-                return;
+                if (error) {
+                    console.log(error);
+                    this.queueStore.enqueue('scout_data', { table: matchScoutTable, data: dbData }, error.message ?? String(error));
+                    anyQueuedOffline = true;
+                }
             }
 
+            this.advanceToNextMatch();
 
-            // Reset all non-preserved data. This marks queuedOffline as false and also submitSuccess as false.
-            // So we mark submitSuccess as true below to update the UI.
-            // After submission allow incrementing of data in the form reset.
-            this.resetFormData(true);
-
-            // Mark the submission as successful and reset the submission data.
-            this.submitSuccess = true;
-            this.submitData = {};
+            this.queuedOffline = anyQueuedOffline;
+            this.submitSuccess = !anyQueuedOffline;
             this.isSubmitting = false;
         },
-        preserveSingleEntryData() {
-            // Iterate over all components and set their default values to be whatever was submitted most recently.
-            this.scoutForm.forEach(section => {
-                section.components.forEach(component => {
-                    if (component.preserveAfterSubmit) {
-                        component.defaultValue = component.value;
-                    }
-                })
-            });
+        advanceToNextMatch() {
+            this.matchNumber = this.matchNumber ? this.matchNumber + 1 : this.matchNumber;
+            this.lastMatchSyncKey = null;
+            this.syncMatchTeams();
         },
-        resetFormData(isIncrement) {
-            // Reset all data to their default values.
-            this.scoutForm.forEach(section => {
-                section.components.forEach(component => {
-                    if (!component.incrementAfterSubmit || !isIncrement) {
-                        component.value = component.defaultValue;
-                    } else {
-                        component.value = component.value + 1;
-                    }
-                    component.error = false;
+        resetMatch() {
+            this.slots.forEach((_, idx) => { this.rows[idx] = this.buildRow(); });
 
-                    console.log(section.key + "-" + component.key + ": " + component.value);
-                })
-            });
-
-            // The form submission no longer has failed since the data is being reset.
             this.queuedOffline = false;
             this.formInvalid = false;
             this.submitSuccess = false;
             this.resetSuccess = true;
-
-            // The match number may have just incremented (or been cleared) —
-            // refresh the schedule-derived team choices to match.
-            this.syncAutoTeams();
         }
     },
     computed: {
-        getAllianceColor() {
-            const switchPos = this.findPrematchComponent('alliance')?.value;
-            let allianceColor = switchPos ? "blue" : "red";
-            return allianceColor;
+        showManualPicker() {
+            return this.manualEntry || this.scheduleLookupFailed;
         },
-        visiblePrematchComponents() {
-            const prematch = this.scoutForm?.find(s => s.key === 'prematch');
-            if (!prematch) return [];
-            // In auto mode, the Alliance field is derived from the chosen
-            // schedule team rather than entered directly, so hide it.
-            if (!this.autoTeamsApplied) return prematch.components;
-            return prematch.components.filter(c => c.key !== 'alliance');
+        hasDirtyIncludedRow() {
+            return this.rows.some((row) => row.dirty && row.included);
         }
     },
     created() {
         this.eventStore = useEventStore();
         this.queueStore = useOfflineQueueStore();
+        this.watchlistStore = useWatchlistStore();
         this.loadScoutForm();
+
+        this.eventStore.updateEvent().then(() => {
+            this.watchlistStore.loadWatchlist(this.eventStore.eventId);
+        });
     },
 }
 </script>
@@ -289,5 +335,57 @@ p {
 .notification-tile {
     background-color: rgb(88, 88, 232);
     color: white
+}
+
+.match-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: safe center;
+}
+
+.match-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.manual-assign-tile {
+    text-align: left;
+}
+
+.manual-assign-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.manual-assign-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.manual-assign-label {
+    font-size: 13px;
+    font-weight: 700;
+    padding: 3px 8px;
+    border-radius: 6px;
+    min-width: 56px;
+    text-align: center;
+}
+
+.manual-assign-label--red {
+    background: rgba(255, 0, 0, 0.15);
+    color: #d32f2f;
+}
+
+.manual-assign-label--blue {
+    background: rgba(0, 0, 255, 0.15);
+    color: #1a5fd3;
+}
+
+.match-rows {
+    margin-top: 16px;
 }
 </style>

--- a/src/views/PicklistView.vue
+++ b/src/views/PicklistView.vue
@@ -7,6 +7,7 @@ import { usePicklistStore } from '@/stores/picklist-store';
 import { useAuthStore } from '@/stores/auth-store';
 import { useEventStore } from '@/stores/event-store';
 import { useOfflineQueueStore } from '@/stores/offline-queue-store';
+import { useWatchlistStore } from '@/stores/watchlist-store';
 import { TIER_GROUPS } from '@/lib/picklist-query';
 import PicklistRow from '@/components/PicklistRow.vue';
 
@@ -14,6 +15,7 @@ const picklistStore = usePicklistStore();
 const authStore = useAuthStore();
 const eventStore = useEventStore();
 const queueStore = useOfflineQueueStore();
+const watchlistStore = useWatchlistStore();
 
 // Which row is expanded
 const expandedTeam = ref<number | null>(null);
@@ -135,6 +137,7 @@ onMounted(async () => {
     if (isObserver.value) return;
     await eventStore.updateEvent();
     await picklistStore.loadAll(eventId.value, userId.value, isLead.value);
+    await watchlistStore.loadWatchlist(eventId.value);
 });
 
 // ─── Expand / collapse row ────────────────────────────────────────────────────
@@ -158,6 +161,13 @@ async function toggleExpand(teamNumber: number) {
 async function togglePicked(teamNumber: number) {
     if (!isLead.value) return;
     await picklistStore.togglePicked(eventId.value, teamNumber);
+}
+
+// ─── Watchlist toggle ──────────────────────────────────────────────────────────
+
+async function toggleWatch(teamNumber: number) {
+    if (!isLead.value) return;
+    await watchlistStore.toggleWatch(eventId.value, teamNumber);
 }
 
 // ─── Save ─────────────────────────────────────────────────────────────────────
@@ -375,9 +385,11 @@ function groupRankOffset(group: string) {
                                     :position="groupRankOffset(group) + index + 1" :show-drag-handle="true" :show-vote-stats="showVoteStats"
                                     :tier-stats="tierStatsFor(teamNumber)" :show-picked="showPickedCheckbox"
                                     :is-picked="picklistStore.isTeamPicked(teamNumber)"
-                                    :can-toggle-picked="isLead" :expanded="expandedTeam === teamNumber"
+                                    :can-toggle-picked="isLead" :watched="watchlistStore.isWatched(teamNumber)"
+                                    :can-toggle-watch="isLead" :expanded="expandedTeam === teamNumber"
                                     :expanded-data="expandedData" :expanded-loading="expandedLoading"
-                                    @toggle-expand="toggleExpand(teamNumber)" @toggle-picked="togglePicked(teamNumber)" />
+                                    @toggle-expand="toggleExpand(teamNumber)" @toggle-picked="togglePicked(teamNumber)"
+                                    @toggle-watch="toggleWatch(teamNumber)" />
                             </template>
                         </draggable>
 
@@ -388,9 +400,11 @@ function groupRankOffset(group: string) {
                                 :position="groupRankOffset(group) + index + 1" :show-drag-handle="false" :show-vote-stats="showVoteStats"
                                 :tier-stats="tierStatsFor(teamNumber)" :show-picked="showPickedCheckbox"
                                 :is-picked="picklistStore.isTeamPicked(teamNumber)"
-                                :can-toggle-picked="isLead" :expanded="expandedTeam === teamNumber"
+                                :can-toggle-picked="isLead" :watched="watchlistStore.isWatched(teamNumber)"
+                                :can-toggle-watch="isLead" :expanded="expandedTeam === teamNumber"
                                 :expanded-data="expandedData" :expanded-loading="expandedLoading"
-                                @toggle-expand="toggleExpand(teamNumber)" @toggle-picked="togglePicked(teamNumber)" />
+                                @toggle-expand="toggleExpand(teamNumber)" @toggle-picked="togglePicked(teamNumber)"
+                                @toggle-watch="toggleWatch(teamNumber)" />
                         </div>
 
                         <div v-if="(picklistStore.activeSections[group] || []).length === 0" class="tier-section-empty">

--- a/src/views/TeamAnalysisView.vue
+++ b/src/views/TeamAnalysisView.vue
@@ -6,6 +6,7 @@ import { uploadFile, updatePhoto } from "@/lib/data-submission";
 import { useEventStore } from "@/stores/event-store";
 import { useViewModeStore } from '@/stores/view-mode-store';
 import { useAuthStore } from "@/stores/auth-store";
+import { useWatchlistStore } from "@/stores/watchlist-store";
 import { projectId, robotPhotoTable, robotPhotoBucket } from "@/lib/constants";
 
 import '@material/web/select/outlined-select';
@@ -33,7 +34,15 @@ import { minWidthForDesktop } from "@/lib/constants";
         <h1>Team Analysis</h1>
         <div v-if="teamLoaded && isDataAvailable">
             <!-- Only show this if the team data is loaded. -->
-            <Dropdown :choices="teamFilters" v-model="currentTeamIndex" @update:modelValue="setTeam"></Dropdown>
+            <div class="team-select-row">
+                <Dropdown :choices="teamFilters" v-model="currentTeamIndex" @update:modelValue="setTeam"></Dropdown>
+                <button v-if="isTeamWatched || isUserLead" type="button" class="watch-star"
+                    :class="{ 'watch-star--active': isTeamWatched, 'watch-star--readonly': !isUserLead }"
+                    :disabled="!isUserLead" @click="toggleTeamWatch"
+                    :title="isUserLead ? (isTeamWatched ? 'Remove from watchlist' : 'Add to watchlist') : 'On the watchlist'">
+                    ★
+                </button>
+            </div>
 
             <div>
                 <div class="analysis-row-tile">
@@ -238,6 +247,7 @@ export default {
             viewMode: null,
             eventStore: null,
             authStore: null,
+            watchlistStore: null,
             teamLoaded: false,
             teamPhotoLoaded: false,
             teamPhotoAvailable: false,
@@ -289,6 +299,15 @@ export default {
 
             // Load auto paths.
             this.loadTeamAutoPaths();
+
+            // Load the watchlist (event-wide, not per team).
+            this.watchlistStore.loadWatchlist(this.eventStore.eventId);
+        },
+        async toggleTeamWatch() {
+            if (!this.isUserLead) return;
+            const teamNumber = this.getTeamNumber();
+            if (teamNumber < 0) return;
+            await this.watchlistStore.toggleWatch(this.eventStore.eventId, teamNumber);
         },
         async loadTeamAutoPaths() {
             const teamNumber = this.getTeamNumber();
@@ -605,6 +624,14 @@ export default {
         isUserWriteAccess() {
             return this.authStore.isWriteAuthorized;
         },
+        isUserLead() {
+            return this.authStore.isLead;
+        },
+        isTeamWatched() {
+            const teamNumber = this.getTeamNumber();
+            if (teamNumber < 0) return false;
+            return this.watchlistStore.isWatched(teamNumber);
+        },
         teamNumber() {
             if (this.currentTeamIndex >= this.teamFilters.length || this.teamFilters.length == 0) {
                 return -1;
@@ -617,6 +644,7 @@ export default {
         this.viewMode = useViewModeStore();
         this.eventStore = useEventStore();
         this.authStore = useAuthStore();
+        this.watchlistStore = useWatchlistStore();
         this.authStore.checkUser();
 
         this.loadLayout();
@@ -637,6 +665,36 @@ export default {
 </script>
 
 <style scoped>
+.team-select-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.watch-star {
+    background: none;
+    border: none;
+    padding: 2px 6px;
+    font-size: 26px;
+    line-height: 1;
+    cursor: pointer;
+    color: rgba(128, 128, 128, 0.35);
+    transition: color 0.15s ease, transform 0.1s ease;
+}
+
+.watch-star:not(:disabled):hover {
+    color: #e0b400;
+    transform: scale(1.1);
+}
+
+.watch-star--active {
+    color: #e0b400;
+}
+
+.watch-star--readonly {
+    cursor: default;
+}
+
 .robot-photo {
     display: block;
     width: 100%;

--- a/supabase/database/schemas/prod.sql
+++ b/supabase/database/schemas/prod.sql
@@ -134,7 +134,13 @@ CREATE TABLE IF NOT EXISTS "public"."MatchData" (
     "postmatch_died" boolean DEFAULT false NOT NULL,
     "postmatch_comments" "text",
     "key" "text",
-    "source" "text"
+    "source" "text",
+    "postmatch_broke" boolean DEFAULT false NOT NULL,
+    "postmatch_beached" boolean DEFAULT false NOT NULL,
+    "auto_failed" boolean DEFAULT false NOT NULL,
+    "postmatch_played_defense" boolean DEFAULT false NOT NULL,
+    "postmatch_defense_impact" "text",
+    CONSTRAINT "MatchData_defense_impact_check" CHECK (("postmatch_defense_impact" IS NULL) OR ("postmatch_defense_impact" = ANY (ARRAY['none'::"text", 'good'::"text", 'minimal'::"text", 'ineffective'::"text"])))
 );
 
 
@@ -333,6 +339,17 @@ CREATE TABLE IF NOT EXISTS "public"."PickList" (
 ALTER TABLE "public"."PickList" OWNER TO "postgres";
 
 
+CREATE TABLE IF NOT EXISTS "public"."Watchlist" (
+    "event_id" "text" NOT NULL,
+    "team_number" smallint NOT NULL,
+    "created_by" "uuid" DEFAULT "auth"."uid"(),
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."Watchlist" OWNER TO "postgres";
+
+
 CREATE TABLE IF NOT EXISTS "public"."RobotPhoto" (
     "team_number" smallint NOT NULL,
     "photo_url" "text"
@@ -413,6 +430,11 @@ ALTER TABLE ONLY "public"."PickList"
 
 
 
+ALTER TABLE ONLY "public"."Watchlist"
+    ADD CONSTRAINT "Watchlist_pkey" PRIMARY KEY ("event_id", "team_number");
+
+
+
 ALTER TABLE ONLY "public"."RobotPhoto"
     ADD CONSTRAINT "RobotPhoto_pkey" PRIMARY KEY ("team_number");
 
@@ -472,6 +494,16 @@ ALTER TABLE ONLY "public"."AutoPath"
 
 ALTER TABLE ONLY "public"."Match"
     ADD CONSTRAINT "Match_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "public"."Event"("event_id");
+
+
+
+ALTER TABLE ONLY "public"."Watchlist"
+    ADD CONSTRAINT "Watchlist_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "public"."Event"("event_id");
+
+
+
+ALTER TABLE ONLY "public"."Watchlist"
+    ADD CONSTRAINT "Watchlist_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "public"."User"("user_id");
 
 
 
@@ -568,6 +600,18 @@ CREATE POLICY "Enable write access for personal lists" ON "public"."PickList" TO
 CREATE POLICY "Enable write access for picklists" ON "public"."PickList" TO "authenticated" USING (true);
 
 
+
+CREATE POLICY "Enable read access for logged in users" ON "public"."Watchlist" FOR SELECT TO "authenticated" USING (true);
+
+
+
+CREATE POLICY "Enable insert for authenticated users only" ON "public"."Watchlist" FOR INSERT TO "authenticated" WITH CHECK (true);
+
+
+
+CREATE POLICY "Enable delete for authenticated users only" ON "public"."Watchlist" FOR DELETE TO "authenticated" USING (true);
+
+
 ALTER TABLE "public"."Event" ENABLE ROW LEVEL SECURITY;
 
 
@@ -599,6 +643,9 @@ ALTER TABLE "public"."Team" ENABLE ROW LEVEL SECURITY;
 
 
 ALTER TABLE "public"."User" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."Watchlist" ENABLE ROW LEVEL SECURITY;
 
 
 

--- a/supabase/migrations/20260825120000_matchdata_add_toggles.sql
+++ b/supabase/migrations/20260825120000_matchdata_add_toggles.sql
@@ -1,0 +1,7 @@
+ALTER TABLE public."MatchData" ADD COLUMN postmatch_broke boolean DEFAULT false NOT NULL;
+ALTER TABLE public."MatchData" ADD COLUMN postmatch_beached boolean DEFAULT false NOT NULL;
+ALTER TABLE public."MatchData" ADD COLUMN postmatch_auto_failed boolean DEFAULT false NOT NULL;
+ALTER TABLE public."MatchData" ADD COLUMN postmatch_played_defense boolean DEFAULT false NOT NULL;
+ALTER TABLE public."MatchData" ADD COLUMN postmatch_defense_impact text;
+ALTER TABLE public."MatchData" ADD CONSTRAINT "MatchData_defense_impact_check"
+    CHECK (postmatch_defense_impact IS NULL OR postmatch_defense_impact = ANY (ARRAY['good'::text, 'minimal'::text, 'ineffective'::text]));

--- a/supabase/migrations/20260825120500_add_watchlist.sql
+++ b/supabase/migrations/20260825120500_add_watchlist.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS public."Watchlist" (
+    "event_id" text NOT NULL REFERENCES public."Event"(event_id),
+    "team_number" smallint NOT NULL,
+    "created_by" uuid DEFAULT auth.uid() REFERENCES public."User"(user_id),
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    PRIMARY KEY (event_id, team_number)
+);
+
+ALTER TABLE public."Watchlist" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Enable read access for logged in users" ON public."Watchlist" FOR SELECT TO authenticated USING (true);
+CREATE POLICY "Enable insert for authenticated users only" ON public."Watchlist" FOR INSERT TO authenticated WITH CHECK (true);
+CREATE POLICY "Enable delete for authenticated users only" ON public."Watchlist" FOR DELETE TO authenticated USING (true);

--- a/supabase/migrations/20260825130000_matchdata_defense_impact_allow_none.sql
+++ b/supabase/migrations/20260825130000_matchdata_defense_impact_allow_none.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public."MatchData" DROP CONSTRAINT "MatchData_defense_impact_check";
+ALTER TABLE public."MatchData" ADD CONSTRAINT "MatchData_defense_impact_check"
+    CHECK (postmatch_defense_impact IS NULL OR postmatch_defense_impact = ANY (ARRAY['none'::text, 'good'::text, 'minimal'::text, 'ineffective'::text]));

--- a/supabase/migrations/20260825140000_matchdata_rename_auto_failed.sql
+++ b/supabase/migrations/20260825140000_matchdata_rename_auto_failed.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public."MatchData" RENAME COLUMN "postmatch_auto_failed" TO "auto_failed";


### PR DESCRIPTION
Chezy Champs needs all 6 teams in a match scouted from one compact, expandable form instead of one team at a time, plus new post-match toggles (Broke?/Beached?/Played Defense? with a conditional Defense Impact chooser/Auto section) and a leads-only watchlist that flags teams with a star in Team Analysis, the Pick List, and the match form.

Closes #19 