### PR TITLE
Add pit scouting tab, new questions, and data status coverage

### DIFF
--- a/src/components/CollapsibleSection.vue
+++ b/src/components/CollapsibleSection.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+// @ts-nocheck
+</script>
+
+<template>
+    <div class="collapsible-section">
+        <button type="button" class="collapsible-header" @click="toggle" :aria-expanded="open">
+            <span class="collapsible-chevron" :class="{ 'collapsible-chevron--closed': !open }">▾</span>
+            <span class="collapsible-title">{{ title }}</span>
+        </button>
+        <div class="collapsible-body" v-show="open">
+            <slot></slot>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+export default {
+    props: {
+        title: {
+            type: String,
+            default: ""
+        },
+        defaultOpen: {
+            type: Boolean,
+            default: true
+        }
+    },
+    data() {
+        return {
+            open: this.defaultOpen
+        }
+    },
+    methods: {
+        toggle() {
+            this.open = !this.open;
+        }
+    }
+}
+</script>
+
+<style scoped>
+.collapsible-section {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    background-color: var(--tile-background-color);
+    border-radius: 10px;
+    margin: 15px;
+    overflow: hidden;
+
+    box-shadow: inset 0 0 0.5px 1px hsla(0, 0%, 100%, 0.1),
+        0 0 0 1px hsla(230, 13%, 9%, 0.075),
+        0 0.3px 0.4px hsla(230, 13%, 9%, 0.02),
+        0 0.9px 1.5px hsla(230, 13%, 9%, 0.045),
+        0 3.5px 6px hsla(230, 13%, 9%, 0.09);
+}
+
+.collapsible-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 16px 20px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    color: var(--primary-text-color);
+    text-align: left;
+}
+
+.collapsible-header:hover {
+    background-color: rgba(128, 128, 128, 0.08);
+}
+
+.collapsible-title {
+    font-size: 1.4em;
+}
+
+.collapsible-chevron {
+    display: inline-block;
+    transition: transform 0.15s ease;
+    flex-shrink: 0;
+}
+
+.collapsible-chevron--closed {
+    transform: rotate(-90deg);
+}
+
+.collapsible-body {
+    padding: 0 20px 20px;
+}
+</style>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -28,6 +28,7 @@ import { useOfflineQueueStore } from "@/stores/offline-queue-store";
             <template v-slot:menu-content>
                 <!-- <RouterLink to="/upload" class="nav-link nav-link-mobile" v-if="isWriteAccess">Data Upload</RouterLink> -->
                 <RouterLink to="/match" class="nav-link nav-link-mobile">Match Scouting</RouterLink>
+                <RouterLink to="/pit" class="nav-link nav-link-mobile">Pit Scouting</RouterLink>
                 <!-- <RouterLink to="/event" class="nav-link nav-link-mobile">Event Analysis</RouterLink> -->
                 <RouterLink to="/team" class="nav-link nav-link-mobile">Team Analysis</RouterLink>
                 <RouterLink to="/match-preview" class="nav-link nav-link-mobile">Match Preview</RouterLink>
@@ -59,6 +60,7 @@ import { useOfflineQueueStore } from "@/stores/offline-queue-store";
     <div class="nav" v-else-if="!viewMode?.isMobile && isLoggedIn">
         <!-- <RouterLink to="/upload" class="nav-link" v-if="isWriteAccess">Data Upload</RouterLink> -->
         <RouterLink to="/match" class="nav-link">Match Scouting</RouterLink>
+        <RouterLink to="/pit" class="nav-link">Pit Scouting</RouterLink>
         <!-- <RouterLink to="/event" class="nav-link">Event Analysis</RouterLink> -->
         <RouterLink to="/team" class="nav-link">Team Analysis</RouterLink>
         <RouterLink to="/match-preview" class="nav-link">Match Preview</RouterLink>

--- a/src/components/PitScoutingSection.vue
+++ b/src/components/PitScoutingSection.vue
@@ -1,0 +1,317 @@
+<script setup lang="ts">
+// @ts-nocheck
+import PitScoutingForm from "@/components/PitScoutingForm.vue";
+
+import { useEventStore } from "@/stores/event-store";
+import { useAuthStore } from "@/stores/auth-store";
+import { fetchTeamPitData } from "@/lib/picklist-query";
+
+import "@material/web/button/filled-button";
+</script>
+
+<template>
+    <div class="pit-section">
+        <h1>Pit Scouting</h1>
+
+        <PitScoutingForm v-if="pitFormMode !== 'view'" :team-number="teamNumber"
+            :pit-data-id="pitFormMode === 'edit' ? pitFormEditId : null" @saved="onPitFormSaved"
+            @cancel="onPitFormCancel">
+        </PitScoutingForm>
+
+        <template v-else>
+            <div v-if="pitSaveMessage" class="data-tile notification-tile pit-save-message">{{ pitSaveMessage }}</div>
+
+            <div v-if="!teamPitDataLoaded">Loading pit scouting data…</div>
+            <div v-else-if="teamPitData.length === 0" class="no-comments">
+                <p>No pit scouting data yet.</p>
+                <md-filled-button v-if="isUserWriteAccess" v-on:click="startAddPit">Pit Scout This
+                    Team</md-filled-button>
+            </div>
+            <template v-else>
+                <div class="pit-actions" v-if="isUserWriteAccess">
+                    <md-filled-button v-on:click="startEditPit(teamPitData[0].id)">Edit</md-filled-button>
+                </div>
+                <ul class="pit-list">
+                    <li v-for="(pit, idx) in teamPitData" :key="idx" class="pit-card">
+                        <div class="pit-stats-grid">
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Drivetrain</div>
+                                <div class="pit-stat-value">{{ formatDrivetrain(pit.drivetrain) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Drive Motor</div>
+                                <div class="pit-stat-value">{{ formatMotorType(pit.driveMotorType) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Dimensions</div>
+                                <div class="pit-stat-value">{{ formatDimensions(pit.length, pit.width) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Weight</div>
+                                <div class="pit-stat-value">{{ pit.weight != null ? pit.weight + ' lbs' : '—' }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Archetype</div>
+                                <div class="pit-stat-value">{{ formatArchetype(pit.archetype) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Language</div>
+                                <div class="pit-stat-value">{{ formatLanguage(pit.language) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Batteries</div>
+                                <div class="pit-stat-value">{{ pit.numBatteries ?? '—' }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Chargers</div>
+                                <div class="pit-stat-value">{{ pit.numChargers ?? '—' }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Traverse</div>
+                                <div class="pit-stat-value">{{ formatTraverse(pit) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Outpost Fuel</div>
+                                <div class="pit-stat-value">{{ formatBool(pit.outpostFuel) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Shoot From</div>
+                                <div class="pit-stat-value">{{ formatShootLocations(pit) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Climb</div>
+                                <div class="pit-stat-value">{{ formatClimb(pit.climb) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Climb in Auto</div>
+                                <div class="pit-stat-value">{{ formatBool(pit.climbAuto) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Auto Strategy</div>
+                                <div class="pit-stat-value">{{ pit.autoStrategy || '—' }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Balls Per Second</div>
+                                <div class="pit-stat-value">{{ pit.cycleRate != null ? pit.cycleRate + '/s' : '—' }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Defense</div>
+                                <div class="pit-stat-value">{{ formatBool(pit.defense) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">New Driver</div>
+                                <div class="pit-stat-value">{{ formatBool(pit.driverNew) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">System Check</div>
+                                <div class="pit-stat-value">{{ formatSystemCheck(pit.systemCheck) }}</div>
+                            </div>
+                            <div class="pit-stat">
+                                <div class="pit-stat-label">Vibe Check</div>
+                                <div class="pit-stat-value">{{ pit.vibe_check != null ? pit.vibe_check + ' / 5' : '—' }}</div>
+                            </div>
+                        </div>
+                        <div class="pit-author">Scouted by {{ pit.author }}</div>
+                    </li>
+                </ul>
+            </template>
+        </template>
+    </div>
+</template>
+
+<script lang="ts">
+export default {
+    props: {
+        teamNumber: {
+            type: Number,
+            required: true
+        }
+    },
+    data() {
+        return {
+            eventStore: null,
+            authStore: null,
+            teamPitData: [],
+            teamPitDataLoaded: false,
+            pitFormMode: 'view',
+            pitFormEditId: null,
+            pitSaveMessage: '',
+            pitSaveMessageTimeout: null
+        }
+    },
+    methods: {
+        async loadTeamPitData() {
+            if (this.teamNumber < 0) {
+                this.teamPitData = [];
+                this.teamPitDataLoaded = true;
+                return;
+            }
+
+            this.teamPitDataLoaded = false;
+            this.teamPitData = await fetchTeamPitData(this.teamNumber, this.eventStore.eventId);
+            this.teamPitDataLoaded = true;
+        },
+        startAddPit() {
+            this.pitFormMode = 'add';
+            this.pitFormEditId = null;
+        },
+        startEditPit(id: number) {
+            this.pitFormMode = 'edit';
+            this.pitFormEditId = id;
+        },
+        onPitFormCancel() {
+            this.pitFormMode = 'view';
+            this.pitFormEditId = null;
+        },
+        async onPitFormSaved({ queuedOffline }: { queuedOffline: boolean }) {
+            this.pitFormMode = 'view';
+            this.pitFormEditId = null;
+
+            if (this.pitSaveMessageTimeout) {
+                clearTimeout(this.pitSaveMessageTimeout);
+            }
+            this.pitSaveMessage = queuedOffline ? "Couldn't save — queued for sync." : "Saved!";
+            this.pitSaveMessageTimeout = setTimeout(() => {
+                this.pitSaveMessage = '';
+            }, 4000);
+
+            await this.loadTeamPitData();
+        },
+        formatDrivetrain(key) {
+            const labels = { swerve: 'Swerve', not_swerve: 'Not Swerve' };
+            return labels[key] ?? key ?? '—';
+        },
+        formatMotorType(key) {
+            const labels = { kraken: 'Kraken', falcon: 'Falcon', neo: 'NEO', other: 'Other' };
+            return labels[key] ?? key ?? '—';
+        },
+        formatArchetype(key) {
+            const labels = { dumper_fixed: 'Dumper/Fixed', turret: 'Turret' };
+            return labels[key] ?? key ?? '—';
+        },
+        formatClimb(key) {
+            const labels = { no_climb: 'No Climb', l1: 'L1', l2: 'L2', l3: 'L3' };
+            return labels[key] ?? key ?? '—';
+        },
+        formatLanguage(key) {
+            const labels = { java: 'Java', cpp: 'C++', python: 'Python', other: 'Other' };
+            return labels[key] ?? key ?? '—';
+        },
+        formatSystemCheck(key) {
+            const labels = {
+                before_every_match: 'Before Every Match',
+                before_most_matches: 'Before Most Matches',
+                sometimes_before_match: 'Sometimes Before a Match',
+                once_or_twice: 'Once or Twice',
+                never: 'Never'
+            };
+            return labels[key] ?? key ?? '—';
+        },
+        formatDimensions(length, width) {
+            if (length == null || width == null) return '—';
+            return `${length}" x ${width}"`;
+        },
+        formatBool(value) {
+            if (value == null) return '—';
+            return value ? 'Yes' : 'No';
+        },
+        formatTraverse(pit) {
+            const parts = [];
+            if (pit.traverseBump) parts.push('Bump');
+            if (pit.traverseTrench) parts.push('Trench');
+            return parts.length > 0 ? parts.join(', ') : 'None';
+        },
+        formatShootLocations(pit) {
+            const parts = [];
+            if (pit.shootClose) parts.push('Close');
+            if (pit.shootTower) parts.push('Tower');
+            if (pit.shootCorner) parts.push('Corner');
+            if (pit.shootTrench) parts.push('Trench');
+            return parts.length > 0 ? parts.join(', ') : 'None';
+        }
+    },
+    computed: {
+        isUserWriteAccess() {
+            return this.authStore.isWriteAuthorized;
+        }
+    },
+    watch: {
+        teamNumber() {
+            this.pitFormMode = 'view';
+            this.pitFormEditId = null;
+            this.loadTeamPitData();
+        }
+    },
+    created() {
+        this.eventStore = useEventStore();
+        this.authStore = useAuthStore();
+        this.authStore.checkUser();
+        this.loadTeamPitData();
+    }
+}
+</script>
+
+<style scoped>
+.pit-section {
+    margin-top: 24px;
+}
+
+.pit-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 10px;
+}
+
+.pit-save-message {
+    margin-bottom: 14px;
+}
+
+.pit-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.pit-card {
+    background: var(--tile-background-color);
+    border: 1px solid rgba(128, 128, 128, 0.2);
+    border-radius: 10px;
+    padding: 12px 14px;
+}
+
+.pit-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    gap: 10px;
+}
+
+.pit-stat-label {
+    font-size: 11px;
+    color: rgba(128, 128, 128, 0.75);
+    margin-bottom: 2px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.pit-stat-value {
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--primary-text-color);
+}
+
+.pit-author {
+    margin-top: 10px;
+    font-size: 11px;
+    color: rgba(128, 128, 128, 0.6);
+}
+
+.no-comments {
+    font-size: 13px;
+    color: rgba(128, 128, 128, 0.7);
+    font-style: italic;
+}
+</style>

--- a/src/lib/2026/pit-scouting-form.ts
+++ b/src/lib/2026/pit-scouting-form.ts
@@ -299,6 +299,36 @@ export async function getPitScoutSchema({ includeTeamSelector = true, existingDa
                     error: false
                 },
                 {
+                    key: "driver_new",
+                    label: "Is Your Driver New?",
+                    type: "switch",
+                    options: {},
+                    defaultValue: false,
+                    value: false,
+                    preserveAfterSubmit: false,
+                    required: false,
+                    error: false
+                },
+                {
+                    key: "system_check",
+                    label: "When Do You Do a System Check?",
+                    type: "dropdown",
+                    options: {
+                        choices: [
+                            { key: "before_every_match", text: "Before Every Match" },
+                            { key: "before_most_matches", text: "Before Most Matches" },
+                            { key: "sometimes_before_match", text: "Sometimes Before a Match" },
+                            { key: "once_or_twice", text: "Only Once or Twice Throughout Comp" },
+                            { key: "never", text: "Never" }
+                        ]
+                    },
+                    defaultValue: 0,
+                    value: 0,
+                    preserveAfterSubmit: false,
+                    required: false,
+                    error: false
+                },
+                {
                     key: "vibe_check",
                     label: "Vibe Check",
                     type: "radio",
@@ -326,7 +356,7 @@ export async function getPitScoutSchema({ includeTeamSelector = true, existingDa
             defaultValue: "",
             value: "",
             preserveAfterSubmit: false,
-            required: true,
+            required: false,
             error: false
         },
     );

--- a/src/lib/data-query.ts
+++ b/src/lib/data-query.ts
@@ -3,7 +3,7 @@
 
 
 import { supabase } from "@/lib/supabase-client";
-import { matchScoutTable, matchScheduleTable, teamInfoTable, teamNumberColumn } from "@/lib/constants";
+import { matchScoutTable, matchScheduleTable, teamInfoTable, teamNumberColumn, pitScoutTable } from "@/lib/constants";
 
 // Qualification matches are the only ones with a schedule known ahead of
 // time (playoff pairings are only decided live), so schedule-based
@@ -73,6 +73,17 @@ export async function queryTeamMatchData(teamNumber, eventId) {
 
 export async function queryEventData(eventId) {
     const { data, error } = await supabase.from(matchScoutTable).select().eq('event', eventId);
+
+    if (error) {
+        console.log(error);
+        return [];
+    }
+
+    return data;
+}
+
+export async function queryEventPitData(eventId) {
+    const { data, error } = await supabase.from(pitScoutTable).select('pit_team_number, created_at').eq('event', eventId);
 
     if (error) {
         console.log(error);

--- a/src/lib/picklist-query.ts
+++ b/src/lib/picklist-query.ts
@@ -73,7 +73,7 @@ export async function fetchTeamMatchStats(teamNumber: number, eventId: string) {
 export async function fetchTeamPitData(teamNumber: number, eventId: string) {
     const { data, error } = await supabase
         .from(pitScoutTable)
-        .select(`id, pit_drivetrain, pit_drive_motor_type, pit_length, pit_width, pit_weight, pit_archetype, pit_language, pit_num_batteries, pit_num_chargers, pit_traverse_bump, pit_traverse_trench, pit_outpost_fuel, pit_shoot_close, pit_shoot_tower, pit_shoot_corner, pit_shoot_trench, pit_climb, pit_climb_auto, pit_auto_strategy, pit_cycle_rate, pit_defense, pit_vibe_check, pit_comments, created_at, ${userTable}(name)`)
+        .select(`id, pit_drivetrain, pit_drive_motor_type, pit_length, pit_width, pit_weight, pit_archetype, pit_language, pit_num_batteries, pit_num_chargers, pit_traverse_bump, pit_traverse_trench, pit_outpost_fuel, pit_shoot_close, pit_shoot_tower, pit_shoot_corner, pit_shoot_trench, pit_climb, pit_climb_auto, pit_auto_strategy, pit_cycle_rate, pit_defense, pit_driver_new, pit_system_check, pit_vibe_check, pit_comments, created_at, ${userTable}(name)`)
         .eq('event', eventId)
         .eq('pit_team_number', teamNumber)
         .order('created_at', { ascending: false });
@@ -107,6 +107,8 @@ export async function fetchTeamPitData(teamNumber: number, eventId: string) {
         autoStrategy: row.pit_auto_strategy,
         cycleRate: row.pit_cycle_rate,
         defense: row.pit_defense,
+        driverNew: row.pit_driver_new,
+        systemCheck: row.pit_system_check,
         vibe_check: row.pit_vibe_check,
         comments: row.pit_comments,
         created_at: row.created_at

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -6,6 +6,7 @@ import { isSiteReadPrivate, isSiteWritePrivate } from "@/lib/constants";
 import { createRouter, createWebHistory } from "vue-router";
 import DataUploadView from "@/views/DataUploadView.vue";
 import MatchScoutView from "@/views/MatchScoutView.vue";
+import PitScoutingView from "@/views/PitScoutingView.vue";
 import TeamAnalysisView from "@/views/TeamAnalysisView.vue";
 import EventAnalysisView from "@/views/EventAnalysisView.vue";
 import MatchPreviewView from "@/views/MatchPreviewView.vue";
@@ -54,6 +55,14 @@ const router = createRouter({
       path: "/team",
       name: "Team Analysis | GreyScout",
       component: TeamAnalysisView,
+      meta: {
+        requiresAuth: isSiteReadPrivate
+      }
+    },
+    {
+      path: "/pit",
+      name: "Pit Scouting | GreyScout",
+      component: PitScoutingView,
       meta: {
         requiresAuth: isSiteReadPrivate
       }

--- a/src/views/DataStatusView.vue
+++ b/src/views/DataStatusView.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 // @ts-nocheck
 
+import CollapsibleSection from "@/components/CollapsibleSection.vue";
+
 import { useEventStore } from "@/stores/event-store";
 import { useAuthStore } from "@/stores/auth-store";
-import { queryEventMatchSchedule, queryEventData, queryTeamNumbers } from "@/lib/data-query";
+import { queryEventMatchSchedule, queryEventData, queryEventPitData, queryTeamNumbers } from "@/lib/data-query";
 import { matchNumberColumn, teamNumberColumn } from "@/lib/constants";
 </script>
 
@@ -15,8 +17,29 @@ import { matchNumberColumn, teamNumberColumn } from "@/lib/constants";
             <p>This page is only available to leads and admins.</p>
         </div>
 
-        <div v-else>
-            <div class="data-tile" v-if="loaded">
+        <div v-else-if="loaded">
+            <CollapsibleSection title="Pit Scouting">
+                <p>{{ pitStats.scoutedTeams }} / {{ pitStats.totalTeams }} teams pit scouted
+                    ({{ pitStats.percent }}%).</p>
+                <div class="legend">
+                    <span class="legend-item"><span class="status-dot status-scouted"></span> Pit scouted</span>
+                    <span class="legend-item"><span class="status-dot status-missing"></span> Not yet pit scouted</span>
+                </div>
+
+                <p v-if="teams.length === 0">No teams loaded for this event yet.</p>
+
+                <div v-else class="pit-status-grid">
+                    <div v-for="team in teams" :key="team.team_number" class="pit-status-cell"
+                        :class="pitScoutedTeams[team.team_number] ? 'cell-scouted' : 'cell-missing'">
+                        <span class="status-dot"
+                            :class="pitScoutedTeams[team.team_number] ? 'status-scouted' : 'status-missing'"></span>
+                        {{ team.team_number }}
+                        <span class="team-name">- {{ team.name }}</span>
+                    </div>
+                </div>
+            </CollapsibleSection>
+
+            <CollapsibleSection title="Match Scouting">
                 <p>{{ completionStats.scoutedSlots }} / {{ completionStats.totalSlots }} team-match slots scouted
                     ({{ completionStats.percent }}%) across {{ qualMatches.length }} qualification matches.</p>
                 <div class="legend">
@@ -26,41 +49,39 @@ import { matchNumberColumn, teamNumberColumn } from "@/lib/constants";
                 </div>
                 <p class="hint">Only qualification matches are shown — match numbers repeat across playoff levels,
                     so scouting entries can't be matched back to a specific playoff match.</p>
-            </div>
 
-            <div class="data-tile" v-if="loaded && qualMatches.length === 0">
-                <p>No qualification schedule loaded for this event yet.</p>
-            </div>
+                <p v-if="qualMatches.length === 0">No qualification schedule loaded for this event yet.</p>
 
-            <div class="data-tile schedule-tile" v-if="loaded && qualMatches.length > 0">
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Match</th>
-                            <th class="red-header">Red 1</th>
-                            <th class="red-header">Red 2</th>
-                            <th class="red-header">Red 3</th>
-                            <th class="blue-header">Blue 1</th>
-                            <th class="blue-header">Blue 2</th>
-                            <th class="blue-header">Blue 3</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr v-for="match in qualMatches" :key="match.key">
-                            <td>Q{{ match.match_number }}</td>
-                            <td v-for="slotKey in slotKeys" :key="slotKey" :class="cellClass(match, slotKey)">
-                                <span v-if="match[slotKey]">
-                                    <span class="status-dot" :class="statusDotClass(match.match_number, match[slotKey])"></span>
-                                    {{ match[slotKey] }}
-                                    <span class="team-name" v-if="teamNameByNumber[match[slotKey]]">
-                                        - {{ teamNameByNumber[match[slotKey]] }}
+                <div v-else class="schedule-table-wrap">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Match</th>
+                                <th class="red-header">Red 1</th>
+                                <th class="red-header">Red 2</th>
+                                <th class="red-header">Red 3</th>
+                                <th class="blue-header">Blue 1</th>
+                                <th class="blue-header">Blue 2</th>
+                                <th class="blue-header">Blue 3</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="match in qualMatches" :key="match.key">
+                                <td>Q{{ match.match_number }}</td>
+                                <td v-for="slotKey in slotKeys" :key="slotKey" :class="cellClass(match, slotKey)">
+                                    <span v-if="match[slotKey]">
+                                        <span class="status-dot" :class="statusDotClass(match.match_number, match[slotKey])"></span>
+                                        {{ match[slotKey] }}
+                                        <span class="team-name" v-if="teamNameByNumber[match[slotKey]]">
+                                            - {{ teamNameByNumber[match[slotKey]] }}
+                                        </span>
                                     </span>
-                                </span>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </CollapsibleSection>
         </div>
     </div>
 </template>
@@ -69,15 +90,19 @@ import { matchNumberColumn, teamNumberColumn } from "@/lib/constants";
 const SLOT_KEYS = ['red1', 'red2', 'red3', 'blue1', 'blue2', 'blue3'];
 
 export default {
+    components: { CollapsibleSection },
     data() {
         return {
             eventStore: null,
             authStore: null,
             loaded: false,
             schedule: [],
+            teams: [],
             teamNameByNumber: {},
             // `${match_number}|${team_number}` -> { count, noShow }
             scoutedByKey: {},
+            // team_number -> true
+            pitScoutedTeams: {},
             slotKeys: SLOT_KEYS
         }
     },
@@ -100,6 +125,12 @@ export default {
 
             const percent = totalSlots > 0 ? Math.round((scoutedSlots / totalSlots) * 100) : 0;
             return { totalSlots, scoutedSlots, percent };
+        },
+        pitStats() {
+            const totalTeams = this.teams.length;
+            const scoutedTeams = this.teams.filter(team => this.pitScoutedTeams[team.team_number]).length;
+            const percent = totalTeams > 0 ? Math.round((scoutedTeams / totalTeams) * 100) : 0;
+            return { totalTeams, scoutedTeams, percent };
         }
     },
     methods: {
@@ -109,13 +140,16 @@ export default {
             await this.eventStore.updateEvent();
             const eventId = this.eventStore.eventId;
 
-            const [schedule, matchData, teams] = await Promise.all([
+            const [schedule, matchData, pitData, teams] = await Promise.all([
                 queryEventMatchSchedule(eventId),
                 queryEventData(eventId),
+                queryEventPitData(eventId),
                 queryTeamNumbers(eventId)
             ]);
 
             this.schedule = schedule;
+
+            this.teams = [...teams].sort((a, b) => a.team_number - b.team_number);
 
             this.teamNameByNumber = {};
             teams.forEach((team) => {
@@ -130,6 +164,11 @@ export default {
                 }
                 this.scoutedByKey[key].count += 1;
                 this.scoutedByKey[key].noShow = this.scoutedByKey[key].noShow || !!row.prematch_noshow;
+            });
+
+            this.pitScoutedTeams = {};
+            pitData.forEach((row) => {
+                this.pitScoutedTeams[row.pit_team_number] = true;
             });
 
             this.loaded = true;
@@ -198,7 +237,7 @@ export default {
     background-color: #e05050;
 }
 
-.schedule-tile {
+.schedule-table-wrap {
     overflow-x: auto;
     max-width: 100%;
 }
@@ -213,5 +252,29 @@ export default {
 
 .blue-header {
     background-color: rgba(0, 0, 224, 0.15);
+}
+
+.pit-status-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 8px;
+    width: 100%;
+}
+
+.pit-status-cell {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 10px;
+    border-radius: 8px;
+    font-size: 0.9em;
+}
+
+.pit-status-cell.cell-scouted {
+    background-color: rgba(58, 184, 58, 0.12);
+}
+
+.pit-status-cell.cell-missing {
+    background-color: rgba(224, 80, 80, 0.12);
 }
 </style>

--- a/src/views/PitScoutingView.vue
+++ b/src/views/PitScoutingView.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+// @ts-nocheck
+import Dropdown from "@/components/Dropdown.vue";
+import PitScoutingSection from "@/components/PitScoutingSection.vue";
+
+import { useEventStore } from "@/stores/event-store";
+import { queryTeamNumbers } from "@/lib/data-query";
+</script>
+
+<template>
+    <div class="main-content">
+        <div v-if="isDataAvailable">
+            <Dropdown :choices="teamFilters" v-model="currentTeamIndex"></Dropdown>
+
+            <PitScoutingSection :team-number="teamNumber"></PitScoutingSection>
+        </div>
+        <div v-else-if="teamsLoaded">
+            <h2>No Data Available</h2>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+export default {
+    data() {
+        return {
+            eventStore: null,
+            teamsLoaded: false,
+            teamFilters: [],
+            currentTeamIndex: 0
+        }
+    },
+    methods: {
+        async loadTeamNumbers() {
+            await this.eventStore.updateEvent();
+            const teamNumbersRows = await queryTeamNumbers(this.eventStore.eventId);
+
+            // Put the teams in a dictionary first in order to sort them by team number.
+            let teamMap = {};
+            teamNumbersRows.forEach(element => {
+                teamMap[element['team_number']] = (
+                    {
+                        "key": element['team_number'],
+                        "text": element['team_number'] + " - " + element['name']
+                    }
+                );
+            });
+
+            this.teamFilters = [];
+            Object.keys(teamMap).forEach(element => {
+                this.teamFilters.push(teamMap[element])
+            });
+
+            this.teamsLoaded = true;
+        }
+    },
+    computed: {
+        isDataAvailable() {
+            return this.teamFilters.length > 0;
+        },
+        teamNumber() {
+            if (this.currentTeamIndex >= this.teamFilters.length || this.teamFilters.length == 0) {
+                return -1;
+            }
+
+            return this.teamFilters[this.currentTeamIndex].key;
+        }
+    },
+    created() {
+        this.eventStore = useEventStore();
+        this.loadTeamNumbers();
+    }
+}
+</script>

--- a/src/views/TeamAnalysisView.vue
+++ b/src/views/TeamAnalysisView.vue
@@ -15,7 +15,7 @@ import "@material/web/button/filled-button";
 import draggable from 'vuedraggable'
 import Dropdown from "@/components/Dropdown.vue";
 import Tile from "@/components/Tile.vue";
-import PitScoutingForm from "@/components/PitScoutingForm.vue";
+import PitScoutingSection from "@/components/PitScoutingSection.vue";
 import AutoPathEditor from "@/components/AutoPathEditor.vue";
 import AutoPathCard from "@/components/AutoPathCard.vue";
 
@@ -23,7 +23,7 @@ import { supabase } from "@/lib/supabase-client";
 import { getTeamAnalysisLayout } from "@/lib/2026/team-analysis-layout";
 import { processLayout } from "@/lib/process-layout";
 import { queryTeamNumbers } from "@/lib/data-query";
-import { fetchTeamComments, fetchTeamPitData } from "@/lib/picklist-query";
+import { fetchTeamComments } from "@/lib/picklist-query";
 import { fetchTeamAutoPaths, setAutoPathDefault } from "@/lib/auto-path-query";
 import { minWidthForDesktop } from "@/lib/constants";
 
@@ -100,105 +100,7 @@ import { minWidthForDesktop } from "@/lib/constants";
                     </ul>
                 </div>
 
-                <div class="pit-section">
-                    <h1>Pit Scouting</h1>
-
-                    <PitScoutingForm v-if="pitFormMode !== 'view'" :team-number="teamNumber"
-                        :pit-data-id="pitFormMode === 'edit' ? pitFormEditId : null" @saved="onPitFormSaved"
-                        @cancel="onPitFormCancel">
-                    </PitScoutingForm>
-
-                    <template v-else>
-                        <div v-if="pitSaveMessage" class="data-tile notification-tile pit-save-message">{{ pitSaveMessage }}</div>
-
-                        <div v-if="!teamPitDataLoaded">Loading pit scouting data…</div>
-                        <div v-else-if="teamPitData.length === 0" class="no-comments">
-                            <p>No pit scouting data yet.</p>
-                            <md-filled-button v-if="isUserWriteAccess" v-on:click="startAddPit">Pit Scout This
-                                Team</md-filled-button>
-                        </div>
-                        <template v-else>
-                            <div class="pit-actions" v-if="isUserWriteAccess">
-                                <md-filled-button v-on:click="startEditPit(teamPitData[0].id)">Edit</md-filled-button>
-                            </div>
-                            <ul class="pit-list">
-                                <li v-for="(pit, idx) in teamPitData" :key="idx" class="pit-card">
-                            <div class="pit-stats-grid">
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Drivetrain</div>
-                                    <div class="pit-stat-value">{{ formatDrivetrain(pit.drivetrain) }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Drive Motor</div>
-                                    <div class="pit-stat-value">{{ formatMotorType(pit.driveMotorType) }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Dimensions</div>
-                                    <div class="pit-stat-value">{{ formatDimensions(pit.length, pit.width) }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Weight</div>
-                                    <div class="pit-stat-value">{{ pit.weight != null ? pit.weight + ' lbs' : '—' }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Archetype</div>
-                                    <div class="pit-stat-value">{{ formatArchetype(pit.archetype) }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Language</div>
-                                    <div class="pit-stat-value">{{ formatLanguage(pit.language) }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Batteries</div>
-                                    <div class="pit-stat-value">{{ pit.numBatteries ?? '—' }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Chargers</div>
-                                    <div class="pit-stat-value">{{ pit.numChargers ?? '—' }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Traverse</div>
-                                    <div class="pit-stat-value">{{ formatTraverse(pit) }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Outpost Fuel</div>
-                                    <div class="pit-stat-value">{{ formatBool(pit.outpostFuel) }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Shoot From</div>
-                                    <div class="pit-stat-value">{{ formatShootLocations(pit) }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Climb</div>
-                                    <div class="pit-stat-value">{{ formatClimb(pit.climb) }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Climb in Auto</div>
-                                    <div class="pit-stat-value">{{ formatBool(pit.climbAuto) }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Auto Strategy</div>
-                                    <div class="pit-stat-value">{{ pit.autoStrategy || '—' }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Balls Per Second</div>
-                                    <div class="pit-stat-value">{{ pit.cycleRate != null ? pit.cycleRate + '/s' : '—' }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Defense</div>
-                                    <div class="pit-stat-value">{{ formatBool(pit.defense) }}</div>
-                                </div>
-                                <div class="pit-stat">
-                                    <div class="pit-stat-label">Vibe Check</div>
-                                    <div class="pit-stat-value">{{ pit.vibe_check != null ? pit.vibe_check + ' / 5' : '—' }}</div>
-                                </div>
-                            </div>
-                            <div class="pit-author">Scouted by {{ pit.author }}</div>
-                        </li>
-                    </ul>
-                        </template>
-                    </template>
-                </div>
+                <PitScoutingSection :team-number="teamNumber"></PitScoutingSection>
 
                 <div class="autopath-section">
                     <h1>Auto Paths</h1>
@@ -262,12 +164,6 @@ export default {
             tileModelList: [],
             teamComments: [],
             teamCommentsLoaded: false,
-            teamPitData: [],
-            teamPitDataLoaded: false,
-            pitFormMode: 'view',
-            pitFormEditId: null,
-            pitSaveMessage: '',
-            pitSaveMessageTimeout: null,
             teamAutoPaths: [],
             teamAutoPathsLoaded: false,
             autoPathFormMode: 'view',
@@ -293,9 +189,6 @@ export default {
 
             // Load scout comments.
             this.loadTeamComments();
-
-            // Load pit scouting answers.
-            this.loadTeamPitData();
 
             // Load auto paths.
             this.loadTeamAutoPaths();
@@ -362,60 +255,6 @@ export default {
             this.autoPathFormMode = 'view';
             this.autoPathEditId = null;
             await this.loadTeamAutoPaths();
-        },
-        async loadTeamPitData() {
-            const teamNumber = this.getTeamNumber();
-            if (teamNumber < 0) {
-                this.teamPitData = [];
-                this.teamPitDataLoaded = true;
-                return;
-            }
-
-            this.teamPitDataLoaded = false;
-            this.teamPitData = await fetchTeamPitData(teamNumber, this.eventStore.eventId);
-            this.teamPitDataLoaded = true;
-        },
-        formatDrivetrain(key) {
-            const labels = { swerve: 'Swerve', not_swerve: 'Not Swerve' };
-            return labels[key] ?? key ?? '—';
-        },
-        formatMotorType(key) {
-            const labels = { kraken: 'Kraken', falcon: 'Falcon', neo: 'NEO', other: 'Other' };
-            return labels[key] ?? key ?? '—';
-        },
-        formatArchetype(key) {
-            const labels = { dumper_fixed: 'Dumper/Fixed', turret: 'Turret' };
-            return labels[key] ?? key ?? '—';
-        },
-        formatClimb(key) {
-            const labels = { none: 'None', l1: 'L1', l2: 'L2', l3: 'L3' };
-            return labels[key] ?? key ?? '—';
-        },
-        formatLanguage(key) {
-            const labels = { java: 'Java', cpp: 'C++', python: 'Python', other: 'Other' };
-            return labels[key] ?? key ?? '—';
-        },
-        formatDimensions(length, width) {
-            if (length == null || width == null) return '—';
-            return `${length}" x ${width}"`;
-        },
-        formatBool(value) {
-            if (value == null) return '—';
-            return value ? 'Yes' : 'No';
-        },
-        formatTraverse(pit) {
-            const parts = [];
-            if (pit.traverseBump) parts.push('Bump');
-            if (pit.traverseTrench) parts.push('Trench');
-            return parts.length > 0 ? parts.join(', ') : 'None';
-        },
-        formatShootLocations(pit) {
-            const parts = [];
-            if (pit.shootClose) parts.push('Close');
-            if (pit.shootTower) parts.push('Tower');
-            if (pit.shootCorner) parts.push('Corner');
-            if (pit.shootTrench) parts.push('Trench');
-            return parts.length > 0 ? parts.join(', ') : 'None';
         },
         async loadTeamComments() {
             const teamNumber = this.getTeamNumber();
@@ -521,9 +360,7 @@ export default {
             this.currentTeamIndex = idx;
             this.photoCacheBust = 0;
 
-            // Switching teams always drops any in-progress pit/auto-path form back to view mode.
-            this.pitFormMode = 'view';
-            this.pitFormEditId = null;
+            // Switching teams always drops any in-progress auto-path form back to view mode.
             this.autoPathFormMode = 'view';
             this.autoPathEditId = null;
 
@@ -531,34 +368,7 @@ export default {
             this.refreshTiles();
             this.getRobotPhoto();
             this.loadTeamComments();
-            this.loadTeamPitData();
             this.loadTeamAutoPaths();
-        },
-        startAddPit() {
-            this.pitFormMode = 'add';
-            this.pitFormEditId = null;
-        },
-        startEditPit(id: number) {
-            this.pitFormMode = 'edit';
-            this.pitFormEditId = id;
-        },
-        onPitFormCancel() {
-            this.pitFormMode = 'view';
-            this.pitFormEditId = null;
-        },
-        async onPitFormSaved({ queuedOffline }: { queuedOffline: boolean }) {
-            this.pitFormMode = 'view';
-            this.pitFormEditId = null;
-
-            if (this.pitSaveMessageTimeout) {
-                clearTimeout(this.pitSaveMessageTimeout);
-            }
-            this.pitSaveMessage = queuedOffline ? "Couldn't save — queued for sync." : "Saved!";
-            this.pitSaveMessageTimeout = setTimeout(() => {
-                this.pitSaveMessage = '';
-            }, 4000);
-
-            await this.loadTeamPitData();
         },
         chooseFiles() {
             let fileInputElement = this.$refs.file;
@@ -703,61 +513,10 @@ export default {
     border-radius: 8px;
 }
 
-.pit-section {
-    margin-top: 24px;
-}
-
 .pit-actions {
     display: flex;
     justify-content: flex-end;
     margin-bottom: 10px;
-}
-
-.pit-save-message {
-    margin-bottom: 14px;
-}
-
-.pit-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.pit-card {
-    background: var(--tile-background-color);
-    border: 1px solid rgba(128, 128, 128, 0.2);
-    border-radius: 10px;
-    padding: 12px 14px;
-}
-
-.pit-stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
-    gap: 10px;
-}
-
-.pit-stat-label {
-    font-size: 11px;
-    color: rgba(128, 128, 128, 0.75);
-    margin-bottom: 2px;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-}
-
-.pit-stat-value {
-    font-size: 15px;
-    font-weight: 700;
-    color: var(--primary-text-color);
-}
-
-.pit-author {
-    margin-top: 10px;
-    font-size: 11px;
-    color: rgba(128, 128, 128, 0.6);
 }
 
 .autopath-section {

--- a/supabase/database/schemas/prod.sql
+++ b/supabase/database/schemas/prod.sql
@@ -220,6 +220,8 @@ CREATE TABLE IF NOT EXISTS "public"."PitData" (
     "pit_auto_strategy" "text" DEFAULT ''::"text" NOT NULL,
     "pit_cycle_rate" real,
     "pit_defense" boolean DEFAULT false NOT NULL,
+    "pit_driver_new" boolean DEFAULT false NOT NULL,
+    "pit_system_check" "text" DEFAULT 'before_every_match'::"text" NOT NULL,
     "pit_vibe_check" smallint NOT NULL,
     "pit_comments" "text",
     CONSTRAINT "PitData_vibe_check_check" CHECK ((("pit_vibe_check" >= 1) AND ("pit_vibe_check" <= 5)))

--- a/supabase/migrations/20260825150000_pit_scouting_driver_new_system_check.sql
+++ b/supabase/migrations/20260825150000_pit_scouting_driver_new_system_check.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public."PitData" ADD COLUMN pit_driver_new boolean DEFAULT false NOT NULL;
+ALTER TABLE public."PitData" ADD COLUMN pit_system_check text DEFAULT 'before_every_match'::text NOT NULL;


### PR DESCRIPTION
Closes #18 (Pit scouting form changes)

Adds new-driver and system-check questions, makes comments optional, and gives pit scouting its own nav tab backed by a shared PitScoutingSection component (also used from Team Preview). Also adds a pit scouting completion section to the Data Status page and makes its sections collapsible for easier navigation.