### PR TITLE
Tier list drag/UX improvements for Chezy Champs (#16)

### DIFF
--- a/src/components/PicklistRow.vue
+++ b/src/components/PicklistRow.vue
@@ -13,6 +13,7 @@ defineProps<{
     showPicked: boolean;
     isPicked: boolean;
     canTogglePicked: boolean;
+    cardStatus: 'red' | 'yellow' | null;
     watched: boolean;
     canToggleWatch: boolean;
     expanded: boolean;
@@ -50,6 +51,22 @@ function formatFieldLabel(field: string) {
         .replace(/\b\w/g, c => c.toUpperCase());
 }
 
+const FLAG_STATS = [
+    { key: 'postmatch_broke', label: 'Break %' },
+    { key: 'postmatch_died', label: 'Die %' },
+    { key: 'postmatch_beached', label: 'Beach %' },
+    { key: 'postmatch_played_defense', label: 'Defense %' }
+];
+
+function computeFlagStats(matchData: unknown[]) {
+    if (!matchData.length) return [];
+    return FLAG_STATS.map(({ key, label }) => {
+        const count = matchData.filter(row => !!row[key]).length;
+        const pct = (count / matchData.length) * 100;
+        return { label, pct: pct.toFixed(0), count, total: matchData.length };
+    });
+}
+
 function formatAvgRank(avgRank: number) {
     return avgRank.toFixed(1);
 }
@@ -72,7 +89,12 @@ function formatAvgRank(avgRank: number) {
                 </div>
             </div>
             <div class="picklist-team-info">
-                <span class="picklist-team-number">{{ team.team_number }}</span>
+                <span class="picklist-team-number">
+                    {{ team.team_number }}
+                    <span v-if="cardStatus" class="picklist-card-indicator" :class="`picklist-card-indicator--${cardStatus}`"
+                        :title="cardStatus === 'red' ? 'Received a red card this event' : 'Received a yellow card this event'">
+                    </span>
+                </span>
                 <span class="picklist-team-name">{{ team.name }}</span>
             </div>
             <div v-if="showVoteStats" class="picklist-vote-badge" @click.stop>
@@ -119,6 +141,12 @@ function formatAvgRank(avgRank: number) {
                         <h3 class="picklist-detail-heading">Match Stats ({{ expandedData.stats.length }}
                             matches)</h3>
                         <div class="picklist-stats-grid">
+                            <div v-for="stat in computeFlagStats(expandedData.stats)" :key="stat.label"
+                                class="picklist-stat-card">
+                                <div class="stat-label">{{ stat.label }}</div>
+                                <div class="stat-avg">{{ stat.pct }}%</div>
+                                <div class="stat-sub">{{ stat.count }} / {{ stat.total }} matches</div>
+                            </div>
                             <div v-for="stat in computeBasicStats(expandedData.stats)" :key="stat.label"
                                 class="picklist-stat-card">
                                 <div class="stat-label">{{ stat.label }}</div>
@@ -280,6 +308,24 @@ function formatAvgRank(avgRank: number) {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+/* ── Card status indicator ── */
+.picklist-card-indicator {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    margin-left: 6px;
+    vertical-align: middle;
+}
+
+.picklist-card-indicator--yellow {
+    background: #e0b400;
+}
+
+.picklist-card-indicator--red {
+    background: #c83c3c;
 }
 
 .picklist-expand-chevron {

--- a/src/lib/picklist-query.ts
+++ b/src/lib/picklist-query.ts
@@ -65,6 +65,56 @@ export async function fetchTeamMatchStats(teamNumber: number, eventId: string) {
     return data ?? [];
 }
 
+export interface TeamMatchSummary {
+    matches: number;
+    brokeCount: number;
+    diedCount: number;
+    beachedCount: number;
+    defenseCount: number;
+    /** Worst card seen across this team's matches at the event, or null if none. */
+    worstCard: 'red' | 'yellow' | null;
+}
+
+/**
+ * Fetch a lightweight per-team summary (card status + broke/died/beached/
+ * defense counts) across every match at the event, in one query. Used to
+ * show card status in the picklist row's collapsed summary view without
+ * requiring a per-team round trip, and to compute the Break/Die/Beach/
+ * Defense % stats shown when a row is expanded.
+ */
+export async function fetchTeamMatchSummaries(eventId: string): Promise<Record<number, TeamMatchSummary>> {
+    const { data, error } = await supabase
+        .from(matchScoutTable)
+        .select('prematch_team_number, postmatch_broke, postmatch_died, postmatch_beached, postmatch_played_defense, postmatch_cards')
+        .eq('event', eventId);
+
+    if (error) {
+        console.error('fetchTeamMatchSummaries error:', error);
+        return {};
+    }
+
+    const summaries: Record<number, TeamMatchSummary> = {};
+    (data ?? []).forEach((row) => {
+        const teamNumber = row.prematch_team_number;
+        if (teamNumber == null) return;
+
+        const summary = summaries[teamNumber] ?? {
+            matches: 0, brokeCount: 0, diedCount: 0, beachedCount: 0, defenseCount: 0, worstCard: null
+        };
+        summary.matches += 1;
+        if (row.postmatch_broke) summary.brokeCount += 1;
+        if (row.postmatch_died) summary.diedCount += 1;
+        if (row.postmatch_beached) summary.beachedCount += 1;
+        if (row.postmatch_played_defense) summary.defenseCount += 1;
+        if (row.postmatch_cards === 'red') summary.worstCard = 'red';
+        else if (row.postmatch_cards === 'yellow' && summary.worstCard !== 'red') summary.worstCard = 'yellow';
+
+        summaries[teamNumber] = summary;
+    });
+
+    return summaries;
+}
+
 /**
  * Fetch pit-scouting answers (drivetrain, weight, language, vibe check) for a team,
  * attributed to their author. Returns array of

--- a/src/stores/picklist-store.ts
+++ b/src/stores/picklist-store.ts
@@ -14,11 +14,12 @@ import {
     computeDemocraticTierGroups,
     parseTeamTiers,
     fetchTeamMatchStats,
+    fetchTeamMatchSummaries,
     fetchTeamComments,
     TIERS,
     TIER_GROUPS
 } from '@/lib/picklist-query';
-import type { Tier, TierGroup, TeamTierStats } from '@/lib/picklist-query';
+import type { Tier, TierGroup, TeamTierStats, TeamMatchSummary } from '@/lib/picklist-query';
 
 export type PicklistTab = 'personal' | 'democratic' | 'team';
 
@@ -95,6 +96,11 @@ export const usePicklistStore = defineStore('picklist', {
             // Per-team expanded data cache
             teamDataCache: {} as Record<number, { stats: unknown[]; comments: unknown[] }>,
 
+            // Per-team card status + broke/died/beached/defense counts across all
+            // matches — loaded up front so card status can show on the collapsed
+            // row without expanding.
+            teamMatchSummaries: {} as Record<number, TeamMatchSummary>,
+
             // Save status
             isSaving: false,
             lastSaveError: null as string | null,
@@ -141,6 +147,10 @@ export const usePicklistStore = defineStore('picklist', {
 
         isTeamPicked(): (teamNumber: number) => boolean {
             return (teamNumber: number) => this.pickedTeams.includes(teamNumber);
+        },
+
+        cardStatusFor(): (teamNumber: number) => 'red' | 'yellow' | null {
+            return (teamNumber: number) => this.teamMatchSummaries[teamNumber]?.worstCard ?? null;
         }
     },
     actions: {
@@ -153,9 +163,14 @@ export const usePicklistStore = defineStore('picklist', {
             await this.loadPersonalList(userId, eventId);
             await this.loadPickedTeams(eventId);
             await this.loadDemocraticList(eventId);
+            await this.loadTeamMatchSummaries(eventId);
             if (isLead) {
                 await this.loadTeamList(eventId);
             }
+        },
+
+        async loadTeamMatchSummaries(eventId: string) {
+            this.teamMatchSummaries = await fetchTeamMatchSummaries(eventId);
         },
 
         async loadTeams(eventId: string) {

--- a/src/views/PicklistView.vue
+++ b/src/views/PicklistView.vue
@@ -38,8 +38,8 @@ window.addEventListener('offline', () => { isOnline.value = false; });
 // main.css), not the window/document, so window.scrollBy is a silent no-op here
 // — the actual scroll container has to be looked up and scrolled directly.
 const AUTOSCROLL_SENSITIVITY = 80; // deadband: no scroll within this many px of the viewport edge
-const AUTOSCROLL_MIN_SPEED = 8; // px/frame right at the deadband boundary, so it's usable immediately
-const AUTOSCROLL_MAX_SPEED = 90; // px/frame right at the true edge
+const AUTOSCROLL_MIN_SPEED = 12; // px/frame right at the deadband boundary, so it's usable immediately (1.5x baseline)
+const AUTOSCROLL_MAX_SPEED = 135; // px/frame right at the true edge (1.5x baseline)
 
 let dragPointerY = null;
 let autoscrollRafId = null;
@@ -268,6 +268,23 @@ function groupRankOffset(group: string) {
     }
     return offset;
 }
+
+// ─── Collapsible tier sections ─────────────────────────────────────────────────
+// Collapsing tiers you're not actively sorting shortens the page, which makes
+// dragging a team from "Unranked" into a tier near the top much less of a
+// scroll marathon as the list fills in.
+const collapsedTiers = ref<Set<string>>(new Set());
+
+function isTierCollapsed(group: string) {
+    return collapsedTiers.value.has(group);
+}
+
+function toggleTierCollapse(group: string) {
+    const next = new Set(collapsedTiers.value);
+    if (next.has(group)) next.delete(group);
+    else next.add(group);
+    collapsedTiers.value = next;
+}
 </script>
 
 <template>
@@ -370,14 +387,17 @@ function groupRankOffset(group: string) {
                 <!-- Tier-grouped sections -->
                 <div v-else class="tier-sections">
                     <div v-for="group in TIER_GROUPS" :key="group" class="tier-section">
-                        <div class="tier-section-header" :class="`tier-section-header--${group}`">
+                        <div class="tier-section-header" :class="`tier-section-header--${group}`"
+                            @click="toggleTierCollapse(group)">
+                            <span class="tier-section-collapse-icon"
+                                :class="{ 'tier-section-collapse-icon--collapsed': isTierCollapsed(group) }">▾</span>
                             <span class="tier-section-name">{{ tierGroupLabel(group) }}</span>
                             <span class="tier-section-count">{{ (picklistStore.activeSections[group] || []).length }}</span>
                         </div>
 
                         <!-- Editable: draggable within and across tier sections -->
-                        <draggable v-if="isEditable" :list="picklistStore.activeSections[group]" group="picklist"
-                            :item-key="(el) => el" handle=".picklist-drag-handle" animation="200"
+                        <draggable v-if="isEditable" v-show="!isTierCollapsed(group)" :list="picklistStore.activeSections[group]"
+                            group="picklist" :item-key="(el) => el" handle=".picklist-drag-handle" animation="200"
                             ghost-class="picklist-row--ghost" :force-fallback="true" :scroll="false"
                             class="tier-section-body" @start="onDragStart" @end="onDragEnd" @change="saveList">
                             <template #item="{ element: teamNumber, index }">
@@ -385,7 +405,8 @@ function groupRankOffset(group: string) {
                                     :position="groupRankOffset(group) + index + 1" :show-drag-handle="true" :show-vote-stats="showVoteStats"
                                     :tier-stats="tierStatsFor(teamNumber)" :show-picked="showPickedCheckbox"
                                     :is-picked="picklistStore.isTeamPicked(teamNumber)"
-                                    :can-toggle-picked="isLead" :watched="watchlistStore.isWatched(teamNumber)"
+                                    :can-toggle-picked="isLead" :card-status="picklistStore.cardStatusFor(teamNumber)"
+                                    :watched="watchlistStore.isWatched(teamNumber)"
                                     :can-toggle-watch="isLead" :expanded="expandedTeam === teamNumber"
                                     :expanded-data="expandedData" :expanded-loading="expandedLoading"
                                     @toggle-expand="toggleExpand(teamNumber)" @toggle-picked="togglePicked(teamNumber)"
@@ -394,20 +415,22 @@ function groupRankOffset(group: string) {
                         </draggable>
 
                         <!-- Read-only (democratic tab) -->
-                        <div v-else class="tier-section-body tier-section-body--static">
+                        <div v-else v-show="!isTierCollapsed(group)" class="tier-section-body tier-section-body--static">
                             <PicklistRow v-for="(teamNumber, index) in picklistStore.activeSections[group]" :key="teamNumber"
                                 :row-id="`picklist-team-demo-${teamNumber}`" :team="picklistStore.teamMap[teamNumber]"
                                 :position="groupRankOffset(group) + index + 1" :show-drag-handle="false" :show-vote-stats="showVoteStats"
                                 :tier-stats="tierStatsFor(teamNumber)" :show-picked="showPickedCheckbox"
                                 :is-picked="picklistStore.isTeamPicked(teamNumber)"
-                                :can-toggle-picked="isLead" :watched="watchlistStore.isWatched(teamNumber)"
+                                :can-toggle-picked="isLead" :card-status="picklistStore.cardStatusFor(teamNumber)"
+                                :watched="watchlistStore.isWatched(teamNumber)"
                                 :can-toggle-watch="isLead" :expanded="expandedTeam === teamNumber"
                                 :expanded-data="expandedData" :expanded-loading="expandedLoading"
                                 @toggle-expand="toggleExpand(teamNumber)" @toggle-picked="togglePicked(teamNumber)"
                                 @toggle-watch="toggleWatch(teamNumber)" />
                         </div>
 
-                        <div v-if="(picklistStore.activeSections[group] || []).length === 0" class="tier-section-empty">
+                        <div v-if="!isTierCollapsed(group) && (picklistStore.activeSections[group] || []).length === 0"
+                            class="tier-section-empty">
                             {{ isEditable ? 'Drag teams here' : 'No teams in this tier' }}
                         </div>
                     </div>
@@ -603,6 +626,20 @@ function groupRankOffset(group: string) {
     padding: 4px 10px;
     margin-bottom: 8px;
     border-left: 4px solid rgba(128, 128, 128, 0.4);
+    cursor: pointer;
+    user-select: none;
+}
+
+.tier-section-collapse-icon {
+    font-size: 12px;
+    color: rgba(128, 128, 128, 0.6);
+    transition: transform 0.2s ease;
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.tier-section-collapse-icon--collapsed {
+    transform: rotate(-90deg);
 }
 
 .tier-section-name {


### PR DESCRIPTION
Increase drag autoscroll speed 1.5x, make tier sections collapsible so dragging into a tier stays reachable as the list grows, surface a red/yellow card indicator on the collapsed row without expanding, and add Break/Die/Beach/Defense % to the expanded match stats.