### PR TITLE
Add scout scheduling to the app

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -27,6 +27,7 @@ import { useOfflineQueueStore } from "@/stores/offline-queue-store";
             </template>
             <template v-slot:menu-content>
                 <!-- <RouterLink to="/upload" class="nav-link nav-link-mobile" v-if="isWriteAccess">Data Upload</RouterLink> -->
+                <RouterLink to="/schedule" class="nav-link nav-link-mobile">Schedule</RouterLink>
                 <RouterLink to="/match" class="nav-link nav-link-mobile">Match Scouting</RouterLink>
                 <RouterLink to="/pit" class="nav-link nav-link-mobile">Pit Scouting</RouterLink>
                 <!-- <RouterLink to="/event" class="nav-link nav-link-mobile">Event Analysis</RouterLink> -->
@@ -34,7 +35,7 @@ import { useOfflineQueueStore } from "@/stores/offline-queue-store";
                 <RouterLink to="/match-preview" class="nav-link nav-link-mobile">Match Preview</RouterLink>
                 <RouterLink to="/picklist" class="nav-link nav-link-mobile">Pick List</RouterLink>
                 <!-- <RouterLink to="/chartbuilder" class="nav-link nav-link-mobile">ChartBuilder</RouterLink> -->
-                <RouterLink to="/data-status" class="nav-link nav-link-mobile" v-if="isLead">Data Status</RouterLink>
+                <RouterLink to="/data-status" class="nav-link nav-link-mobile">Data Status</RouterLink>
                 <RouterLink to="/account" class="nav-link nav-link-mobile">Account</RouterLink>
             </template>
         </HamburgerMenu>
@@ -59,6 +60,7 @@ import { useOfflineQueueStore } from "@/stores/offline-queue-store";
     </div>
     <div class="nav" v-else-if="!viewMode?.isMobile && isLoggedIn">
         <!-- <RouterLink to="/upload" class="nav-link" v-if="isWriteAccess">Data Upload</RouterLink> -->
+        <RouterLink to="/schedule" class="nav-link">Schedule</RouterLink>
         <RouterLink to="/match" class="nav-link">Match Scouting</RouterLink>
         <RouterLink to="/pit" class="nav-link">Pit Scouting</RouterLink>
         <!-- <RouterLink to="/event" class="nav-link">Event Analysis</RouterLink> -->
@@ -66,7 +68,7 @@ import { useOfflineQueueStore } from "@/stores/offline-queue-store";
         <RouterLink to="/match-preview" class="nav-link">Match Preview</RouterLink>
         <RouterLink to="/picklist" class="nav-link">Pick List</RouterLink>
         <!-- <RouterLink to="/chartbuilder" class="nav-link">ChartBuilder</RouterLink> -->
-        <RouterLink to="/data-status" class="nav-link" v-if="isLead">Data Status</RouterLink>
+        <RouterLink to="/data-status" class="nav-link">Data Status</RouterLink>
 
         <div class="nav-dark-mode nav-right" @click="toggleUserDarkMode">
             <md-icon slot="icon" v-if="isDarkMode">dark_mode</md-icon>
@@ -137,9 +139,6 @@ export default {
         },
         isWriteAccess() {
             return this.authStore?.isWriteAuthorized;
-        },
-        isLead() {
-            return this.authStore?.isLead;
         }
     },
     methods: {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -19,6 +19,7 @@ export const pickListTable = "PickList";
 export const userProfileTable = "UserProfile";
 export const autoPathTable = "AutoPath";
 export const watchlistTable = "Watchlist";
+export const scoutAssignmentTable = "ScoutAssignment";
 
 // Picklist types
 export const pickListTypePersonal = "personal";

--- a/src/lib/data-query.ts
+++ b/src/lib/data-query.ts
@@ -3,7 +3,7 @@
 
 
 import { supabase } from "@/lib/supabase-client";
-import { matchScoutTable, matchScheduleTable, teamInfoTable, teamNumberColumn, pitScoutTable } from "@/lib/constants";
+import { matchScoutTable, matchScheduleTable, teamInfoTable, teamNumberColumn, pitScoutTable, eventInfoTable } from "@/lib/constants";
 
 // Qualification matches are the only ones with a schedule known ahead of
 // time (playoff pairings are only decided live), so schedule-based
@@ -73,6 +73,19 @@ export async function queryTeamMatchData(teamNumber, eventId) {
 
 export async function queryEventData(eventId) {
     const { data, error } = await supabase.from(matchScoutTable).select().eq('event', eventId);
+
+    if (error) {
+        console.log(error);
+        return [];
+    }
+
+    return data;
+}
+
+// All events, newest first — used to label assignments from past events by
+// name and sort them.
+export async function queryAllEvents() {
+    const { data, error } = await supabase.from(eventInfoTable).select('event_id, name, start_date').order('start_date', { ascending: false });
 
     if (error) {
         console.log(error);

--- a/src/lib/scout-assignment-query.ts
+++ b/src/lib/scout-assignment-query.ts
@@ -1,0 +1,91 @@
+// @ts-nocheck
+
+import { supabase } from '@/lib/supabase-client';
+import { scoutAssignmentTable } from '@/lib/constants';
+
+/**
+ * All scout assignments for an event. Returns rows of
+ * { id, event_id, match_number, alliance, slot_index, scout_user_id, created_at, updated_at }.
+ * Assignments are by alliance station (red/blue, slot 1-3) rather than by a
+ * specific team, since the team occupying a station changes match-to-match.
+ */
+export async function queryScoutAssignments(eventId) {
+    const { data, error } = await supabase
+        .from(scoutAssignmentTable)
+        .select('*')
+        .eq('event_id', eventId);
+
+    if (error) {
+        console.error('queryScoutAssignments error:', error);
+        return [];
+    }
+
+    return data ?? [];
+}
+
+/**
+ * All scout assignments for a given scout, across every event (not just the
+ * current one). Used by the Schedule page so a scout can still see
+ * assignments from a past event even after the app's active event changes.
+ */
+export async function queryScoutAssignmentsForUser(userId) {
+    const { data, error } = await supabase
+        .from(scoutAssignmentTable)
+        .select('*')
+        .eq('scout_user_id', userId);
+
+    if (error) {
+        console.error('queryScoutAssignmentsForUser error:', error);
+        return [];
+    }
+
+    return data ?? [];
+}
+
+/**
+ * Assign (or reassign) a scout to an alliance station slot (up to 3 per
+ * alliance per match), or clear it by passing scoutUserId as null. Upserts
+ * on the (event_id, match_number, alliance, slot_index) unique slot.
+ * Returns the error object, or null on success.
+ */
+export async function assignScout(eventId, matchNumber, alliance, slotIndex, scoutUserId) {
+    const { error } = await supabase
+        .from(scoutAssignmentTable)
+        .upsert({
+            event_id: eventId,
+            match_number: matchNumber,
+            alliance,
+            slot_index: slotIndex,
+            scout_user_id: scoutUserId,
+            updated_at: new Date().toISOString()
+        }, { onConflict: 'event_id,match_number,alliance,slot_index' });
+
+    return error;
+}
+
+/**
+ * Assign the same scout to many alliance station slots in one request —
+ * used by the schedule grid's fill-drag (copy one cell's scout across a
+ * dragged range) so a large drag doesn't fire one request per cell.
+ * `slots` is an array of { matchNumber, alliance, slotIndex }. Returns the
+ * error object, or null on success.
+ */
+export async function assignScoutToSlots(eventId, slots, scoutUserId) {
+    if (slots.length === 0) return null;
+
+    const updatedAt = new Date().toISOString();
+    const rows = slots.map(({ matchNumber, alliance, slotIndex }) => ({
+        event_id: eventId,
+        match_number: matchNumber,
+        alliance,
+        slot_index: slotIndex,
+        scout_user_id: scoutUserId,
+        updated_at: updatedAt
+    }));
+
+    const { error } = await supabase
+        .from(scoutAssignmentTable)
+        .upsert(rows, { onConflict: 'event_id,match_number,alliance,slot_index' });
+
+    return error;
+}

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -17,6 +17,7 @@ import ResetPasswordView from "@/views/ResetPasswordView.vue";
 import AccountView from "@/views/AccountView.vue";
 import PicklistView from "@/views/PicklistView.vue";
 import DataStatusView from "@/views/DataStatusView.vue";
+import ScoutScheduleView from "@/views/ScoutScheduleView.vue";
 import { useAuthStore } from "@/stores/auth-store";
 
 const router = createRouter({
@@ -127,8 +128,15 @@ const router = createRouter({
       name: "Data Status | GreyScout",
       component: DataStatusView,
       meta: {
-        requiresAuth: isSiteReadPrivate,
-        requiresLead: true
+        requiresAuth: isSiteReadPrivate
+      }
+    },
+    {
+      path: "/schedule",
+      name: "Schedule | GreyScout",
+      component: ScoutScheduleView,
+      meta: {
+        requiresAuth: isSiteReadPrivate
       }
     }
   ],
@@ -137,20 +145,13 @@ const router = createRouter({
 router.beforeEach(async (to, from, next) => {
   let authStore = useAuthStore();
 
-  // Prevent unauthorized users from accessing the app if the app is private,
-  // and always check the user when the destination is role-gated (this check
-  // is independent of site-wide read privacy).
-  if (isSiteReadPrivate || to.meta.requiresLead) {
+  // Prevent unauthorized users from accessing the app if the app is private.
+  if (isSiteReadPrivate) {
     await authStore.checkUser();
   }
 
   if (isSiteReadPrivate && to.meta.requiresAuth && !authStore.isUserLoggedIn) {
     next('/login');
-    return;
-  }
-
-  if (to.meta.requiresLead && !authStore.isLead) {
-    next('/');
     return;
   }
 

--- a/src/views/DataStatusView.vue
+++ b/src/views/DataStatusView.vue
@@ -4,20 +4,20 @@
 import CollapsibleSection from "@/components/CollapsibleSection.vue";
 
 import { useEventStore } from "@/stores/event-store";
-import { useAuthStore } from "@/stores/auth-store";
 import { queryEventMatchSchedule, queryEventData, queryEventPitData, queryTeamNumbers } from "@/lib/data-query";
 import { matchNumberColumn, teamNumberColumn } from "@/lib/constants";
 </script>
 
 <template>
     <div class="main-content">
-        <h1>Data Status</h1>
-
-        <div v-if="!authStore?.isLead" class="data-tile">
-            <p>This page is only available to leads and admins.</p>
+        <div class="page-header">
+            <h1>Data Status</h1>
+            <button type="button" class="refresh-button" @click="loadData" :disabled="!loaded">
+                {{ loaded ? 'Refresh' : 'Loading…' }}
+            </button>
         </div>
 
-        <div v-else-if="loaded">
+        <div v-if="loaded">
             <CollapsibleSection title="Pit Scouting">
                 <p>{{ pitStats.scoutedTeams }} / {{ pitStats.totalTeams }} teams pit scouted
                     ({{ pitStats.percent }}%).</p>
@@ -94,7 +94,6 @@ export default {
     data() {
         return {
             eventStore: null,
-            authStore: null,
             loaded: false,
             schedule: [],
             teams: [],
@@ -190,15 +189,38 @@ export default {
     },
     created() {
         this.eventStore = useEventStore();
-        this.authStore = useAuthStore();
-        this.authStore.checkUser().then(() => {
-            if (this.authStore.isLead) this.loadData();
-        });
+        this.loadData();
     }
 }
 </script>
 
 <style scoped>
+.page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.refresh-button {
+    padding: 8px 16px;
+    border-radius: 8px;
+    border: none;
+    background-color: var(--accent-color);
+    color: var(--primary-text-color);
+    cursor: pointer;
+    font: inherit;
+}
+
+.refresh-button:hover:not(:disabled) {
+    background-color: var(--header-hover-color);
+}
+
+.refresh-button:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
 .legend {
     display: flex;
     flex-wrap: wrap;

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -111,8 +111,8 @@ export default {
                 return;
             }
 
-            this.authStore.checkUser();
-            this.$router.push("/picklist");
+            await this.authStore.checkUser();
+            this.$router.push(this.authStore.role === 'member' ? '/schedule' : '/picklist');
         },
         async sendPasswordReset() {
             this.resetError = "";

--- a/src/views/ScoutScheduleView.vue
+++ b/src/views/ScoutScheduleView.vue
@@ -1,0 +1,517 @@
+<script setup lang="ts">
+// @ts-nocheck
+
+import CollapsibleSection from "@/components/CollapsibleSection.vue";
+
+import { useEventStore } from "@/stores/event-store";
+import { useAuthStore } from "@/stores/auth-store";
+import { queryEventMatchSchedule, queryAllEvents } from "@/lib/data-query";
+import { fetchAllUsers } from "@/lib/user-query";
+import { queryScoutAssignments, queryScoutAssignmentsForUser, assignScout, assignScoutToSlots } from "@/lib/scout-assignment-query";
+</script>
+
+<template>
+    <div class="main-content">
+        <div class="page-header">
+            <h1>Schedule</h1>
+            <button type="button" class="refresh-button" @click="loadData" :disabled="!loaded">
+                {{ loaded ? 'Refresh' : 'Loading…' }}
+            </button>
+        </div>
+
+        <div v-if="!loaded" class="data-tile">
+            <p>Loading your schedule…</p>
+        </div>
+
+        <template v-else>
+            <div v-if="currentAssignments.length === 0" class="data-tile">
+                <p>You don't have any scouting assignments yet for <strong>{{ eventStore.eventName }}</strong>.
+                    A lead assigns scouts to matches from this page — check back once the schedule has
+                    been set.</p>
+                <p v-if="pastGroups.length > 0" class="hint">You do have assignments from a previous
+                    event — see "Past Assignments" below.</p>
+            </div>
+
+            <div v-else class="schedule-table-wrap">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Match</th>
+                            <th>Alliance</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="assignment in currentAssignments" :key="`${assignment.match_number}|${assignment.alliance}${assignment.slot_index}`">
+                            <td>Q{{ assignment.match_number }}</td>
+                            <td :class="allianceClass(assignment.alliance)">
+                                {{ allianceLabel(assignment.alliance) }}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <CollapsibleSection v-if="authStore?.isLead" title="Manage Scout Schedule">
+                <p>Assign up to 3 scouts to each alliance per qualification match. Assignments are by
+                    station, not by team, so they carry over automatically as the actual teams rotate
+                    through matches. Drag the small square in a cell's corner across other cells to
+                    copy that scout to all of them at once, like an Excel fill handle.</p>
+
+                <div class="scout-legend" v-if="assignableUsers.length > 0">
+                    <span v-for="person in assignableUsers" :key="person.user_id" class="scout-legend-item">
+                        <span class="scout-legend-swatch" :style="{ backgroundColor: colorForUser(person.user_id) }"></span>
+                        {{ person.name || 'Unnamed user' }}
+                    </span>
+                </div>
+
+                <p v-if="qualMatches.length === 0">No qualification schedule loaded for this event yet.</p>
+
+                <div v-else class="schedule-table-wrap">
+                    <table class="assignment-table" :class="{ 'is-filling': fillDrag.active }">
+                        <thead>
+                            <tr>
+                                <th>Match</th>
+                                <th class="red-header" colspan="3">Red</th>
+                                <th class="blue-header" colspan="3">Blue</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="(match, rowIndex) in qualMatches" :key="match.key">
+                                <td>Q{{ match.match_number }}</td>
+                                <td v-for="(slotKey, colIndex) in slotKeys" :key="slotKey" class="assignment-cell"
+                                    :class="[slotKey.startsWith('red') ? 'red-cell' : 'blue-cell', cellInFillRange(rowIndex, colIndex) ? 'fill-range' : '']"
+                                    :data-row="rowIndex" :data-col="colIndex"
+                                    @mouseover="onFillDragEnter(rowIndex, colIndex)">
+                                    <select class="assignment-select"
+                                        :value="adminScoutFor(match.match_number, slotKey)"
+                                        :style="scoutSelectStyle(adminScoutFor(match.match_number, slotKey))"
+                                        @change="onAdminAssignChange(match.match_number, slotKey, $event.target.value)">
+                                        <option value="">Unassigned</option>
+                                        <option v-for="person in assignableUsers" :key="person.user_id" :value="person.user_id">
+                                            {{ person.name || 'Unnamed user' }}
+                                        </option>
+                                    </select>
+                                    <div class="fill-handle" @mousedown="startFillDrag(rowIndex, colIndex, $event)"></div>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <p v-if="assignmentError" class="form-error">{{ assignmentError }}</p>
+            </CollapsibleSection>
+
+            <CollapsibleSection v-if="pastGroups.length > 0" title="Past Assignments"
+                :default-open="currentAssignments.length === 0">
+                <div v-for="group in pastGroups" :key="group.eventId" class="past-event-group">
+                    <h2 class="past-event-title">{{ group.eventName }}</h2>
+                    <div class="schedule-table-wrap">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Match</th>
+                                    <th>Alliance</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr v-for="assignment in group.assignments" :key="`${assignment.match_number}|${assignment.alliance}${assignment.slot_index}`">
+                                    <td>Q{{ assignment.match_number }}</td>
+                                    <td :class="allianceClass(assignment.alliance)">
+                                        {{ allianceLabel(assignment.alliance) }}
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </CollapsibleSection>
+        </template>
+    </div>
+</template>
+
+<script lang="ts">
+const SLOT_KEYS = ['red1', 'red2', 'red3', 'blue1', 'blue2', 'blue3'];
+
+export default {
+    components: { CollapsibleSection },
+    data() {
+        return {
+            eventStore: null,
+            authStore: null,
+            loaded: false,
+            schedule: [],
+            currentAssignments: [],
+            pastGroups: [],
+            slotKeys: SLOT_KEYS,
+            // Admin (lead/admin) scheduling state.
+            people: [],
+            // `${match_number}|${alliance}${slot_index}` -> scout_user_id
+            assignedScoutByKey: {},
+            assignmentError: "",
+            // Excel-style fill-handle drag state for the admin grid.
+            fillDrag: {
+                active: false,
+                startRow: -1,
+                startCol: -1,
+                endRow: -1,
+                endCol: -1,
+                sourceValue: ''
+            }
+        }
+    },
+    computed: {
+        qualMatches() {
+            return this.schedule.filter((m) => m.comp_level === 'qm');
+        },
+        assignableUsers() {
+            return this.people
+                .filter((person) => person.role !== 'observer')
+                .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+        }
+    },
+    methods: {
+        allianceLabel(alliance) {
+            if (alliance === 'red') return 'Red';
+            if (alliance === 'blue') return 'Blue';
+            return '—';
+        },
+        allianceClass(alliance) {
+            if (alliance === 'red') return 'red-cell';
+            if (alliance === 'blue') return 'blue-cell';
+            return '';
+        },
+        sortAssignments(assignments) {
+            return [...assignments].sort((a, b) => a.match_number - b.match_number);
+        },
+        adminScoutFor(matchNumber, slotKey) {
+            return this.assignedScoutByKey[`${matchNumber}|${slotKey}`] || '';
+        },
+        // Deterministic per-scout color (same user always gets the same
+        // hue) so a lead can spot who's assigned where at a glance. Spread
+        // evenly around the full ROYGBIV wheel by position in the sorted
+        // roster, rather than hashing, so neighboring scouts in a small
+        // team don't end up with two hard-to-tell-apart hues.
+        colorForUser(userId) {
+            const index = this.assignableUsers.findIndex((person) => person.user_id === userId);
+            const count = this.assignableUsers.length || 1;
+            const hue = index >= 0 ? Math.round((index / count) * 360) : 0;
+            return `hsl(${hue}, 45%, 28%)`;
+        },
+        scoutSelectStyle(scoutUserId) {
+            if (!scoutUserId) return {};
+            return { backgroundColor: this.colorForUser(scoutUserId), color: '#fff' };
+        },
+        async onAdminAssignChange(matchNumber, slotKey, newScoutUserId) {
+            this.assignmentError = "";
+            const key = `${matchNumber}|${slotKey}`;
+            const previousScoutUserId = this.assignedScoutByKey[key] || '';
+            this.assignedScoutByKey[key] = newScoutUserId || null;
+
+            const alliance = slotKey.slice(0, -1);
+            const slotIndex = parseInt(slotKey.slice(-1), 10);
+
+            const error = await assignScout(this.eventStore.eventId, matchNumber, alliance, slotIndex, newScoutUserId || null);
+
+            if (error) {
+                this.assignmentError = error.message ?? 'Unable to save scout assignment.';
+                this.assignedScoutByKey[key] = previousScoutUserId;
+            }
+        },
+        cellInFillRange(rowIndex, colIndex) {
+            if (!this.fillDrag.active) return false;
+            const minRow = Math.min(this.fillDrag.startRow, this.fillDrag.endRow);
+            const maxRow = Math.max(this.fillDrag.startRow, this.fillDrag.endRow);
+            const minCol = Math.min(this.fillDrag.startCol, this.fillDrag.endCol);
+            const maxCol = Math.max(this.fillDrag.startCol, this.fillDrag.endCol);
+            return rowIndex >= minRow && rowIndex <= maxRow && colIndex >= minCol && colIndex <= maxCol;
+        },
+        startFillDrag(rowIndex, colIndex, event) {
+            event.preventDefault();
+            const match = this.qualMatches[rowIndex];
+            const slotKey = this.slotKeys[colIndex];
+
+            this.fillDrag = {
+                active: true,
+                startRow: rowIndex,
+                startCol: colIndex,
+                endRow: rowIndex,
+                endCol: colIndex,
+                sourceValue: this.adminScoutFor(match.match_number, slotKey)
+            };
+
+            window.addEventListener('mouseup', this.endFillDrag);
+            window.addEventListener('mousemove', this.onFillDragMove);
+        },
+        onFillDragEnter(rowIndex, colIndex) {
+            if (!this.fillDrag.active) return;
+            this.fillDrag.endRow = rowIndex;
+            this.fillDrag.endCol = colIndex;
+        },
+        // Belt-and-suspenders alongside the per-cell @mouseover: follows the
+        // cursor directly so a fast drag can't skip a cell and leave the
+        // fill range stuck short of where the mouse actually is.
+        onFillDragMove(event) {
+            if (!this.fillDrag.active) return;
+            const cell = document.elementFromPoint(event.clientX, event.clientY)?.closest('td.assignment-cell');
+            if (!cell) return;
+            this.fillDrag.endRow = parseInt(cell.dataset.row, 10);
+            this.fillDrag.endCol = parseInt(cell.dataset.col, 10);
+        },
+        async endFillDrag() {
+            if (!this.fillDrag.active) return;
+            window.removeEventListener('mouseup', this.endFillDrag);
+            window.removeEventListener('mousemove', this.onFillDragMove);
+
+            const { startRow, startCol, endRow, endCol, sourceValue } = this.fillDrag;
+            this.fillDrag.active = false;
+
+            const minRow = Math.min(startRow, endRow);
+            const maxRow = Math.max(startRow, endRow);
+            const minCol = Math.min(startCol, endCol);
+            const maxCol = Math.max(startCol, endCol);
+
+            // A plain click with no drag — nothing to copy.
+            if (minRow === maxRow && minCol === maxCol) return;
+
+            const targets = [];
+            for (let row = minRow; row <= maxRow; row++) {
+                for (let col = minCol; col <= maxCol; col++) {
+                    if (row === startRow && col === startCol) continue;
+                    targets.push({ matchNumber: this.qualMatches[row].match_number, slotKey: this.slotKeys[col] });
+                }
+            }
+
+            this.assignmentError = "";
+            targets.forEach(({ matchNumber, slotKey }) => {
+                this.assignedScoutByKey[`${matchNumber}|${slotKey}`] = sourceValue || null;
+            });
+
+            const error = await assignScoutToSlots(
+                this.eventStore.eventId,
+                targets.map(({ matchNumber, slotKey }) => ({
+                    matchNumber,
+                    alliance: slotKey.slice(0, -1),
+                    slotIndex: parseInt(slotKey.slice(-1), 10)
+                })),
+                sourceValue || null
+            );
+
+            if (error) {
+                this.assignmentError = error.message ?? `Unable to save ${targets.length} scout assignment(s).`;
+                // Reload the grid from the server so the failed optimistic
+                // update doesn't leave stale values on screen.
+                this.loadData();
+            }
+        },
+        async loadData() {
+            this.loaded = false;
+
+            await this.eventStore.updateEvent();
+            const currentEventId = this.eventStore.eventId;
+            const myUserId = this.authStore.currentUserId;
+
+            const [schedule, allAssignments, events] = await Promise.all([
+                queryEventMatchSchedule(currentEventId),
+                queryScoutAssignmentsForUser(myUserId),
+                queryAllEvents()
+            ]);
+
+            this.schedule = schedule;
+
+            this.currentAssignments = this.sortAssignments(
+                allAssignments.filter((assignment) => assignment.event_id === currentEventId)
+            );
+
+            // Group any assignments from other events by event, so a scout
+            // can still find them even after the app's active event moves on.
+            const pastAssignmentsByEvent = {};
+            allAssignments
+                .filter((assignment) => assignment.event_id !== currentEventId)
+                .forEach((assignment) => {
+                    if (!pastAssignmentsByEvent[assignment.event_id]) pastAssignmentsByEvent[assignment.event_id] = [];
+                    pastAssignmentsByEvent[assignment.event_id].push(assignment);
+                });
+
+            // `events` is already ordered newest-first, so filtering it keeps
+            // the past groups in that same order.
+            this.pastGroups = events
+                .filter((event) => pastAssignmentsByEvent[event.event_id])
+                .map((event) => ({
+                    eventId: event.event_id,
+                    eventName: event.name,
+                    assignments: this.sortAssignments(pastAssignmentsByEvent[event.event_id])
+                }));
+
+            if (this.authStore.isLead) {
+                const [people, eventAssignments] = await Promise.all([
+                    fetchAllUsers(),
+                    queryScoutAssignments(currentEventId)
+                ]);
+
+                this.people = people;
+
+                this.assignedScoutByKey = {};
+                eventAssignments.forEach((row) => {
+                    this.assignedScoutByKey[`${row.match_number}|${row.alliance}${row.slot_index}`] = row.scout_user_id;
+                });
+            }
+
+            this.loaded = true;
+        }
+    },
+    created() {
+        this.eventStore = useEventStore();
+        this.authStore = useAuthStore();
+        this.authStore.checkUser().then(() => this.loadData());
+    },
+    beforeUnmount() {
+        window.removeEventListener('mouseup', this.endFillDrag);
+        window.removeEventListener('mousemove', this.onFillDragMove);
+    }
+}
+</script>
+
+<style scoped>
+.page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.refresh-button {
+    padding: 8px 16px;
+    border-radius: 8px;
+    border: none;
+    background-color: var(--accent-color);
+    color: var(--primary-text-color);
+    cursor: pointer;
+    font: inherit;
+}
+
+.refresh-button:hover:not(:disabled) {
+    background-color: var(--header-hover-color);
+}
+
+.refresh-button:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
+.schedule-table-wrap {
+    overflow-x: auto;
+    max-width: 100%;
+}
+
+.red-cell {
+    background-color: rgba(224, 0, 0, 0.15);
+}
+
+.blue-cell {
+    background-color: rgba(0, 0, 224, 0.15);
+}
+
+.red-header {
+    background-color: rgba(224, 0, 0, 0.15);
+}
+
+.blue-header {
+    background-color: rgba(0, 0, 224, 0.15);
+}
+
+.hint {
+    font-size: 0.9em;
+    opacity: 0.8;
+}
+
+.past-event-group {
+    margin-bottom: 20px;
+}
+
+.past-event-group:last-child {
+    margin-bottom: 0;
+}
+
+.past-event-title {
+    font-size: 1.1em;
+    margin: 0 0 8px;
+}
+
+.scout-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.scout-legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9em;
+}
+
+.scout-legend-swatch {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    flex-shrink: 0;
+}
+
+.assignment-select {
+    display: block;
+    width: 100%;
+    padding: 10px 8px;
+    font-size: 1rem;
+    border-radius: 6px;
+    border: 1px solid rgba(128, 128, 128, 0.35);
+    background-color: transparent;
+    color: var(--primary-text-color);
+    cursor: pointer;
+}
+
+.assignment-select:hover {
+    border-color: rgba(128, 128, 128, 0.6);
+}
+
+/* When a scout is assigned, scoutSelectStyle() sets an inline
+   background/text color per-scout, overriding these defaults. */
+.assignment-select option {
+    color: initial;
+    background-color: initial;
+}
+
+.assignment-cell {
+    position: relative;
+}
+
+.assignment-table.is-filling {
+    user-select: none;
+}
+
+.fill-handle {
+    position: absolute;
+    right: 2px;
+    bottom: 2px;
+    width: 9px;
+    height: 9px;
+    background-color: var(--md-sys-color-primary);
+    border: 1px solid var(--tile-background-color);
+    border-radius: 1px;
+    cursor: crosshair;
+    opacity: 0;
+}
+
+.assignment-cell:hover .fill-handle {
+    opacity: 1;
+}
+
+.fill-range {
+    outline: 2px dashed var(--md-sys-color-primary);
+    outline-offset: -2px;
+}
+
+.form-error {
+    color: #c0392b;
+}
+</style>

--- a/supabase/database/schemas/prod.sql
+++ b/supabase/database/schemas/prod.sql
@@ -352,6 +352,23 @@ CREATE TABLE IF NOT EXISTS "public"."Watchlist" (
 ALTER TABLE "public"."Watchlist" OWNER TO "postgres";
 
 
+CREATE TABLE IF NOT EXISTS "public"."ScoutAssignment" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "event_id" "text" NOT NULL,
+    "match_number" smallint NOT NULL,
+    "scout_user_id" "uuid",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "alliance" "text" NOT NULL,
+    "slot_index" smallint NOT NULL,
+    CONSTRAINT "ScoutAssignment_alliance_check" CHECK (("alliance" = ANY (ARRAY['red'::"text", 'blue'::"text"]))),
+    CONSTRAINT "ScoutAssignment_slot_index_check" CHECK ((("slot_index" >= 1) AND ("slot_index" <= 3)))
+);
+
+
+ALTER TABLE "public"."ScoutAssignment" OWNER TO "postgres";
+
+
 CREATE TABLE IF NOT EXISTS "public"."RobotPhoto" (
     "team_number" smallint NOT NULL,
     "photo_url" "text"
@@ -437,6 +454,11 @@ ALTER TABLE ONLY "public"."Watchlist"
 
 
 
+ALTER TABLE ONLY "public"."ScoutAssignment"
+    ADD CONSTRAINT "ScoutAssignment_pkey" PRIMARY KEY ("id");
+
+
+
 ALTER TABLE ONLY "public"."RobotPhoto"
     ADD CONSTRAINT "RobotPhoto_pkey" PRIMARY KEY ("team_number");
 
@@ -466,6 +488,10 @@ CREATE UNIQUE INDEX "picklist_personal_unique" ON "public"."PickList" USING "btr
 
 
 CREATE UNIQUE INDEX "picklist_team_unique" ON "public"."PickList" USING "btree" ("event_id", "type") WHERE ("type" = 'team'::"text");
+
+
+
+CREATE UNIQUE INDEX "scoutassignment_slot_unique" ON "public"."ScoutAssignment" USING "btree" ("event_id", "match_number", "alliance", "slot_index");
 
 
 
@@ -506,6 +532,16 @@ ALTER TABLE ONLY "public"."Watchlist"
 
 ALTER TABLE ONLY "public"."Watchlist"
     ADD CONSTRAINT "Watchlist_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "public"."User"("user_id");
+
+
+
+ALTER TABLE ONLY "public"."ScoutAssignment"
+    ADD CONSTRAINT "ScoutAssignment_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "public"."Event"("event_id");
+
+
+
+ALTER TABLE ONLY "public"."ScoutAssignment"
+    ADD CONSTRAINT "ScoutAssignment_scout_user_id_fkey" FOREIGN KEY ("scout_user_id") REFERENCES "public"."User"("user_id");
 
 
 
@@ -614,6 +650,22 @@ CREATE POLICY "Enable insert for authenticated users only" ON "public"."Watchlis
 CREATE POLICY "Enable delete for authenticated users only" ON "public"."Watchlist" FOR DELETE TO "authenticated" USING (true);
 
 
+
+CREATE POLICY "Enable read access for logged in users" ON "public"."ScoutAssignment" FOR SELECT TO "authenticated" USING (true);
+
+
+
+CREATE POLICY "Enable insert for authenticated users only" ON "public"."ScoutAssignment" FOR INSERT TO "authenticated" WITH CHECK (true);
+
+
+
+CREATE POLICY "Enable update for authenticated users only" ON "public"."ScoutAssignment" FOR UPDATE TO "authenticated" USING (true);
+
+
+
+CREATE POLICY "Enable delete for authenticated users only" ON "public"."ScoutAssignment" FOR DELETE TO "authenticated" USING (true);
+
+
 ALTER TABLE "public"."Event" ENABLE ROW LEVEL SECURITY;
 
 
@@ -648,6 +700,9 @@ ALTER TABLE "public"."User" ENABLE ROW LEVEL SECURITY;
 
 
 ALTER TABLE "public"."Watchlist" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."ScoutAssignment" ENABLE ROW LEVEL SECURITY;
 
 
 

--- a/supabase/migrations/20260826120000_add_scout_assignment.sql
+++ b/supabase/migrations/20260826120000_add_scout_assignment.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS public."ScoutAssignment" (
+    "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+    "event_id" text NOT NULL REFERENCES public."Event"(event_id),
+    "match_number" smallint NOT NULL,
+    "team_number" smallint NOT NULL,
+    "scout_user_id" uuid REFERENCES public."User"(user_id),
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+    PRIMARY KEY ("id")
+);
+
+-- One assignment per match/team slot per event; assigning a new scout to an
+-- already-assigned slot updates the row rather than creating a duplicate.
+CREATE UNIQUE INDEX "scoutassignment_slot_unique" ON public."ScoutAssignment" USING btree (event_id, match_number, team_number);
+
+ALTER TABLE public."ScoutAssignment" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Enable read access for logged in users" ON public."ScoutAssignment" FOR SELECT TO authenticated USING (true);
+CREATE POLICY "Enable insert for authenticated users only" ON public."ScoutAssignment" FOR INSERT TO authenticated WITH CHECK (true);
+CREATE POLICY "Enable update for authenticated users only" ON public."ScoutAssignment" FOR UPDATE TO authenticated USING (true);
+CREATE POLICY "Enable delete for authenticated users only" ON public."ScoutAssignment" FOR DELETE TO authenticated USING (true);

--- a/supabase/migrations/20260827120000_scout_assignment_by_station.sql
+++ b/supabase/migrations/20260827120000_scout_assignment_by_station.sql
@@ -1,0 +1,16 @@
+-- Scout assignments are now by alliance station (red/blue, slot 1-3) rather
+-- than by a specific team number, since the team occupying a station
+-- changes match-to-match while the station itself doesn't. The table is
+-- still empty in production, so this is a plain column swap.
+
+DROP INDEX IF EXISTS "scoutassignment_slot_unique";
+
+ALTER TABLE public."ScoutAssignment" DROP COLUMN "team_number";
+
+ALTER TABLE public."ScoutAssignment"
+    ADD COLUMN "alliance" text NOT NULL,
+    ADD COLUMN "slot_index" smallint NOT NULL,
+    ADD CONSTRAINT "ScoutAssignment_alliance_check" CHECK (alliance IN ('red', 'blue')),
+    ADD CONSTRAINT "ScoutAssignment_slot_index_check" CHECK (slot_index BETWEEN 1 AND 3);
+
+CREATE UNIQUE INDEX "scoutassignment_slot_unique" ON public."ScoutAssignment" USING btree (event_id, match_number, alliance, slot_index);


### PR DESCRIPTION
Leads/admins can assign up to 3 scouts per alliance per qualification match on the Schedule page, by station rather than by team so assignments carry over automatically as teams rotate through matches. Scouts see their own upcoming (and past-event) assignments there too, without exposing which team they're scouting. Data Status is now open to all members instead of leads-only, and both pages gained a refresh button.