### PR TITLE
Make auto paths time-relative with a rainbow timing editor

### DIFF
--- a/docs/auto-paths.md
+++ b/docs/auto-paths.md
@@ -39,7 +39,7 @@ replacing that PNG and re-measuring `FIELD_BOUNDS` in
 | `name` | `text` | Scout-provided name, renameable |
 | `alliance` | `text` | `"red"` or `"blue"` — the alliance the path was **drawn** as |
 | `side` | `text` | `"left"` or `"right"` — the starting side it was **drawn** as |
-| `path` | `jsonb` | Array of `{ x, y }` points, each in `[0, 1]`, in the frame described below |
+| `path` | `jsonb` | Array of `{ x, y, t }` points, `x`/`y` in `[0, 1]` in the frame described below, `t` the point's recorded time as a `[0, 1]` fraction of the path's normalized duration (see "Timing" below). `t` is optional — paths saved before [issue #35](https://github.com/Team973/greyscout/issues/35) don't have it |
 | `is_default` | `boolean` | This team's default auto for Match Preview to pre-select (see below) |
 
 A partial unique index, `autopath_default_unique` on `(team_number, event)
@@ -115,10 +115,11 @@ straight through — optionally side-mirrored via `transformPath` — and let
 
 | File | Purpose |
 |---|---|
-| [`src/components/AutoPathCanvas.vue`](../src/components/AutoPathCanvas.vue) | The field SVG, background image is `src/assets/2026-field.png`. Two modes: single editable/viewable path (`points`/`color` props), or a read-only multi-path overlay (`layers` prop: `[{ key, points, color }]`) used by Match Preview. Drawing uses Pointer Events (`touch-action: none`) so mouse, touch, and pen all work the same way. |
-| [`src/components/AutoPathEditor.vue`](../src/components/AutoPathEditor.vue) | Create/edit form: name, alliance/side dropdowns, the canvas, Reset/Save/Cancel/Delete. Reuses `submitScoutData`/`updateScoutData` from `data-submission.ts` (same as pit scouting) so a failed save enqueues into the existing offline-queue FAB instead of a bespoke path. |
+| [`src/components/AutoPathCanvas.vue`](../src/components/AutoPathCanvas.vue) | The field SVG, background image is `src/assets/2026-field.png`. Two modes: single editable/viewable path (`points`/`color` props), or a read-only multi-path overlay (`layers` prop: `[{ key, points, color }]`) used by Match Preview. Drawing uses Pointer Events (`touch-action: none`) so mouse, touch, and pen all work the same way. Also owns per-point time recording and time-relative playback — see "Timing" below. |
+| [`src/components/AutoPathTimeline.vue`](../src/components/AutoPathTimeline.vue) | The scrub/timing-adjustment bar rendered below the canvas in the editor — see "Timing" below. |
+| [`src/components/AutoPathEditor.vue`](../src/components/AutoPathEditor.vue) | Create/edit form: name, alliance/side dropdowns, the canvas, the timeline, Reset/Save/Cancel/Delete. Reuses `submitScoutData`/`updateScoutData` from `data-submission.ts` (same as pit scouting) so a failed save enqueues into the existing offline-queue FAB instead of a bespoke path. |
 | [`src/components/AutoPathCard.vue`](../src/components/AutoPathCard.vue) | Read-only list card for Team Analysis: renders a saved path plus an alliance/side "view as" toggle (backed by `transformPath`), a default-auto badge/button, and an Edit button. |
-| [`src/lib/2026/auto-path-field.ts`](../src/lib/2026/auto-path-field.ts) | `transformPath()`, plus the alliance/side dropdown choice lists. |
+| [`src/lib/2026/auto-path-field.ts`](../src/lib/2026/auto-path-field.ts) | `transformPath()`, the alliance/side dropdown choice lists, and the timing helpers `pointTime()`/`pathTimeColor()` shared by the canvas and timeline. |
 | [`src/lib/auto-path-query.ts`](../src/lib/auto-path-query.ts) | Supabase queries: `fetchTeamAutoPaths`, `fetchAutoPathById`, `deleteAutoPath`, `setAutoPathDefault`. |
 
 The editor, card, and Match Preview overlay canvases all render at `large`
@@ -134,6 +135,158 @@ screen). `AutoPathCanvas` implements this by never clearing its point
 buffer on pointer-up — every stroke just keeps appending to the same
 ordered point array, which is rendered as one `<polyline>`. "Reset" in the
 editor is the only way to clear it.
+
+### Timing ([issue #35](https://github.com/Team973/greyscout/issues/35))
+
+Playback used to move the marker at constant speed along the path's arc
+length, taking `duration` (20s) end to end regardless of how the scout
+actually drew it. It's now **time-relative**: each point carries its own
+recorded time (`t`, `[0,1]` fraction of the normalized duration), and
+`markerAtTime()` in `AutoPathCanvas.vue` interpolates between points by
+that recorded time, not by distance — a stretch the scout drew quickly
+plays back quickly, a stretch drawn slowly (e.g. a scoring action) plays
+back slowly, independent of how much on-field distance either covers.
+
+- **Recording.** `AutoPathCanvas` tracks each point's *active* elapsed
+  drawing time in a parallel `drawTimestamps` array (raw ms, not yet
+  normalized) — active meaning the clock only runs while the pointer is
+  down, pausing across a lift/resume between strokes (a lift is a
+  recording pause per "Continuous-path drawing" above, not something the
+  robot did, so it shouldn't inject dead time into the pacing). Every
+  emitted point is normalized on the fly: `t = drawTimestamps[i] /
+  drawTimestamps[last]`, so the saved path's `t`s always span exactly
+  `[0, 1]` — this is what "normalized to a 20-second standard duration"
+  means: the *shape* of the pacing is recorded, and it's stretched or
+  compressed to fill `duration` at playback time (`t * duration`),
+  regardless of how many real seconds the scout spent drawing.
+- **Resuming a path.** If drawing resumes on top of points that already
+  have a `t` (continuing after a lift, or continuing to draw on a loaded
+  saved path), `resyncTimestamps()` reconstructs an assumed elapsed-ms
+  baseline from the existing `t`s (`t * duration`) so the new strokes'
+  timing stays on a comparable scale before everything gets re-normalized.
+- **Legacy paths.** Points saved before this existed have no `t`.
+  `pointTime()` in `auto-path-field.ts` falls back to even spacing by
+  index in that case, so old paths still animate (roughly their old
+  constant-speed behavior) instead of breaking. `transformPath()` passes
+  `t` through unchanged (via `{ ...p }`) — don't reintroduce a hand-picked
+  `{ x, y }` there, it'll silently drop timing again.
+- **Rainbow rendering, fixed by point order.** `AutoPathCanvas`'s
+  `time-gradient` prop (on for the editor only, off for cards/Match
+  Preview, which still use one flat `color` per path) renders the path as
+  many short colored segments instead of one `<polyline>`, hue driven by
+  each segment's midpoint **rank** — `((i-1) + i) / 2 / (len-1)` — via
+  `pathTimeColor()` (red at the start → violet at the end). Deliberately
+  **not** driven by each point's recorded `t`: coloring by rank means "the
+  red part of the path" always means the same stretch of drawing, however
+  its timing gets edited on the timeline below — the path's colors never
+  repaint. The animated marker's color follows suit via `rankAtTime()` (the
+  inverse of `markerAtTime()` — given the current time progress, what
+  fixed-rank color is that point in the path currently colored?), so the
+  marker's color always matches the segment it's visibly passing through
+  even after a non-uniform timing edit. The editor's canvas always has
+  `time-gradient` on, so a scout sees the same fixed coloring while
+  drawing, adjusting timing, and previewing.
+- **Start/End labels (flat-color viewer only).** The rainbow gradient
+  already shows direction at a glance (red = start, violet = end), so
+  `AutoPathCanvas` only draws an end-point dot and "Start"/"End" text labels
+  (`labelPos()`) when `time-gradient` is *off* — the flat single-`color`
+  viewer used by `AutoPathCard`/Match Preview has no such built-in cue.
+- **The timeline editor** (`AutoPathTimeline.vue`, rendered below the
+  canvas once `points.length > 2`): a horizontal bar that answers "how many
+  seconds does each (fixed) color take?", modeled as resizable regions
+  rather than draggable points — an earlier dot-based version (drag a small
+  floating circle to re-time the point under it) was hard to land a precise
+  drag on and had the two-neighbor clamping logic in `dragHandleTo` right
+  next to your finger/cursor, which read as "unexpected" behavior; a
+  region's own border is both a much bigger drag target and a much more
+  legible one, since you're visibly grabbing the edge of the thing you're
+  resizing.
+  - **Regions** (`regions`, one per pair of adjacent boundaries in
+    `handleIndices`): positioned and *widthed* by real time (`left`/`width`
+    from the boundary points' own `t`s, so a region's width literally is
+    how many seconds that stretch takes) and rendered as a `linear-gradient`
+    sampled at several stops across the region's own point-rank span (not
+    one flat midpoint color — a flat color only matches the canvas's
+    per-point coloring at the region's exact middle, drifting further off
+    at the edges the wider the region is; multiple gradient stops keep each
+    inter-stop hop small enough that the RGB-space interpolation CSS
+    gradients do stays visually indistinguishable from `pathTimeColor`'s
+    HSL-based hue sweep). Adjacent regions share a boundary point's exact
+    color as their touching gradient stop, so they meet with no visible
+    seam — the whole bar reads as one continuous rainbow that exactly
+    matches the canvas above it, stretching or compressing as regions are resized.
+  - **Draggable bounds** (`interiorBounds`): a divider rendered at the
+    border between two regions — a wide (~16px) invisible hit area
+    centered on the boundary's time position, with a slim visible line in
+    the middle, so a drag is easy to land without needing to hit a small
+    exact point. Dragging one resizes both neighboring regions
+    (`rescaleRange()` on each) without changing either region's color:
+    "red for 4 seconds" always means the same red stretch of the path,
+    just currently taking 4 seconds. The two `rescaleRange()` calls split
+    the point range at `cur.pointIndex + 1`, not `cur.pointIndex` — the
+    dragged boundary's own point is the shared edge between the two
+    ranges, and only the *first* call may touch it. An earlier version had
+    the second call start at `cur.pointIndex` too, so it read back the
+    value the first call had just written as its own "old" reference
+    instead of the true original — silently corrupting both the boundary's
+    saved time and every point after it. This is why the boundary's
+    persisted `t` must be checked against what it was dragged to, not just
+    that the UI *looks* right immediately after dragging.
+  - Dragging is also clamped to a `MIN_REGION_T` (~500ms of the 20s
+    duration) on either side of the boundary being moved, not just enough
+    to prevent inverting past a neighbor. A region allowed to shrink
+    arbitrarily thin gives `requestAnimationFrame` — which only samples
+    `animProgress` every ~16ms during playback — too few frames to render
+    through it, so the marker visibly teleports across that stretch instead
+    of gliding. (An earlier fix for the same symptom added a CSS
+    `transition` on the marker's `cx`/`cy` to fake a glide; that was
+    reverted — it desynced the marker's rendered *position* from its color
+    and from the timeline's scrub bar, which both still update instantly
+    off the same `animProgress`, since only position was artificially
+    delayed. Capping how thin a region can get fixes the root cause instead
+    of papering over it.)
+  - The bound set starts at 10 roughly-equal regions by point count (exposing every raw drawn point —
+    there can be hundreds — as its own region would be unusable) but isn't
+    fixed — double-click a region to split it (adds a bound at the point
+    nearest the clicked time), double-click a bound to remove it (merges
+    its two regions back into one). The bar's own far-left/far-right edges
+    are the two absolute end anchors (`t=0`/`t=1`) and aren't rendered as
+    interactive bounds at all — there's no region beyond them to resize.
+  - **The scrub thumb and the ruler below the bar** (`tickSeconds`,
+    1-second resolution, major/labeled every 5s) are also positioned by
+    real time, same as the regions and bounds — the ruler itself never
+    moves regardless of any edit, it's just seconds.
+  - Dragging a bound only re-seeds `handleIndices` (the set of point
+    indices with a bound) from scratch when `points.length` itself changes
+    (still drawing) — never by proportionally remapping the *existing*
+    indices, which was tried first and silently collapsed bounds onto each
+    other after enough small growth steps (rounding error compounds over
+    ~one recompute per drawn point in a stroke). A custom split/merge only
+    "sticks" once the scout has stopped drawing and the point count stops
+    changing, matching the normal draw-first-then-adjust workflow.
+- **Play preview while editing.** `AutoPathEditor.vue` has its own Play/Stop
+  button (mirroring `AutoPathCard.vue`'s), wired to the same canvas via
+  `:playing`/`@finished`. Its `previewProgress` binding
+  (`canvasPreviewProgress`) passes through the timeline's scrub value only
+  while *not* playing — `AutoPathCanvas` treats any non-null
+  `previewProgress` as taking priority over the play animation, so without
+  this guard the scrub thumb (which defaults to `0`, not `null`) would
+  permanently pin the marker and the play animation would never visibly move.
+  `AutoPathCanvas` also emits a `progress` event every animation frame
+  (alongside updating its own internal `animProgress`); the editor forwards
+  that straight into `scrubProgress`, so the timeline's white scrub bar
+  visibly tracks along in real time while playing, instead of sitting
+  frozen whereever it was last left from manual scrubbing — from the
+  timeline's own view, playback and scrubbing are the same "where is the
+  white bar" state, just driven by a different source.
+- **Timing edits are disabled while playing.** `AutoPathTimeline` takes a
+  `disabled` prop (`AutoPathEditor` passes `isPlaying`) that ignores bound
+  drag/split/merge and manual scrubbing, and a `disabled` watcher cleanly
+  drops any drag/scrub already in progress the instant playback starts.
+  Editing the same points the canvas is actively animating out from under
+  the edit was the original source of the timeline feeling "glitchy" and
+  getting stuck — the bounds dim and the hint text swaps to say playback is
+  in progress; pressing stop hands editing back.
 
 ---
 
@@ -223,6 +376,38 @@ Each alliance tile (Red/Blue) has an "Auto Path Preview" sub-tile:
   feel on a real mobile device in particular hasn't been confirmed by
   either party yet.
 
+**Timing (issue #35)** was verified live via Claude-in-Chrome: drew a path
+with deliberately slow-then-fast pacing, confirmed the saved `t`s were
+monotonic `[0,1]` and matched the drawn pacing, confirmed a handle drag
+persisted correctly, and confirmed scrub/play both landed the marker at the
+expected point via `markerAtTime`. Also confirmed two pre-existing
+(`t`-less) saved paths still load and play without error under the
+even-spacing fallback. One caveat found along the way: dispatching
+synthetic `PointerEvent`s with a fabricated `pointerId` from a JS console
+(as opposed to real input, or the browser-automation tool's own drag
+action) throws inside `setPointerCapture()`, silently aborting the
+drag-start handler — real user input never hits this, so it's a testing
+artifact rather than a product bug, but worth knowing if you reach for the
+same shortcut later.
+
+A later pass fixed the `rescaleRange()` double-processing bug described
+above (the boundary's saved `t` didn't match where it was dragged to) and
+re-verified it two ways: a standalone numeric replay of `dragHandleTo`'s
+exact logic against known before/after values (no browser needed), and live
+via Claude-in-Chrome — drew a 12-point path (the drawing tool's synthetic
+clicks each register as two points, pointerdown + a same-position
+pointermove — harmless, just denser than a real single click, and not
+something worth "fixing" since real input isn't affected), dragged an
+interior bound to a specific target time, saved, and confirmed via
+`supabase db query --linked` that the persisted point's `t` matched the
+drag target exactly. The same session also confirmed, by reading the live
+Vue component's `fill` style during playback against an independent
+recompute of `pathTimeColor(rankAtTime(...))`, that the marker's color
+stays exactly in sync with the timeline/canvas rainbow at every instant —
+this was checked specifically because the CSS-transition marker-smoothing
+approach mentioned above had briefly broken that sync before being reverted
+in favor of the `MIN_REGION_T` fix.
+
 ## Future work
 
 - Per-path thumbnail caching if the auto-path list grows long enough that
@@ -230,3 +415,8 @@ Each alliance tile (Red/Blue) has an "Auto Path Preview" sub-tile:
 - Undo (not just full Reset) while drawing.
 - Re-measure `FIELD_BOUNDS` if `2026-field.png` is ever swapped for a
   corrected or higher-res export.
+- The timeline's drag/double-click handle interactions haven't been
+  confirmed on a real touch device — `touch-action: none` is set, but
+  double-tap-to-add/remove in particular may need real hardware to
+  validate (see the `setPointerCapture` caveat above for why simulating
+  this from a script isn't reliable).

--- a/src/components/AutoPathCanvas.vue
+++ b/src/components/AutoPathCanvas.vue
@@ -15,12 +15,26 @@ import fieldImage from "@/assets/2026-field.png";
 
             <!-- Single-path mode (editor / per-path card view). -->
             <template v-if="!hasLayers">
-                <polyline v-if="displayPoints.length > 1" :points="pointsToPolyline(displayPoints)" class="path-line"
-                    :style="{ stroke: color }"></polyline>
+                <template v-if="timeGradient && gradientSegments.length > 0">
+                    <line v-for="(seg, idx) in gradientSegments" :key="idx" :x1="seg.x1" :y1="seg.y1" :x2="seg.x2"
+                        :y2="seg.y2" class="path-line" :style="{ stroke: seg.color }"></line>
+                </template>
+                <polyline v-else-if="displayPoints.length > 1" :points="pointsToPolyline(displayPoints)"
+                    class="path-line" :style="{ stroke: color }"></polyline>
                 <circle v-if="displayPoints.length > 0" v-bind="toView(displayPoints[0])" r="3.5" class="path-start"
-                    :style="{ fill: color }"></circle>
+                    :style="{ fill: timeGradient ? pathTimeColor(0) : color }"></circle>
+                <!-- The rainbow gradient already shows start (red) vs end
+                     (violet) at a glance; the flat single-color viewer
+                     (cards, not the editor) has no such cue, so it gets an
+                     end marker and text labels instead. -->
+                <template v-if="!timeGradient">
+                    <circle v-if="displayPoints.length > 1" v-bind="toView(displayPoints[displayPoints.length - 1])"
+                        r="3.5" class="path-end" :style="{ fill: color }"></circle>
+                    <text v-if="displayPoints.length > 0" v-bind="labelPos(displayPoints[0])" class="path-label">Start</text>
+                    <text v-if="displayPoints.length > 1" v-bind="labelPos(displayPoints[displayPoints.length - 1])" class="path-label">End</text>
+                </template>
                 <circle v-if="animatedMarker" v-bind="animatedMarker" r="6" class="path-robot"
-                    :style="{ fill: color }"></circle>
+                    :style="{ fill: timeGradient ? pathTimeColor(markerColorFraction) : color }"></circle>
             </template>
 
             <!-- Multi-path overlay mode (Match Preview). -->
@@ -46,6 +60,7 @@ import fieldImage from "@/assets/2026-field.png";
 
 <script lang="ts">
 import { allianceRed, allianceBlue } from "@/lib/constants";
+import { pointTime, pathTimeColor } from "@/lib/2026/auto-path-field";
 
 // Intrinsic aspect ratio of 2026-field.png (7992x3240), scaled down for a tidy viewBox.
 const VIEW_W = 740;
@@ -59,29 +74,26 @@ const VIEW_H = 300;
 // map into this sub-region, not the full canvas.
 const FIELD_BOUNDS = { left: 0.13113, right: 0.86874, top: 0.05278, bottom: 0.94691 };
 
-// Constant-speed position along a polyline of already-view-space {cx, cy}
-// points, at fraction `t` (0..1) of the path's own total arc length. Doing
-// this in view space (rather than the raw [0,1] point frame) matters because
-// VIEW_W/VIEW_H preserve the field image's true aspect ratio, so distances
-// there are physically proportional in both axes.
-function markerAtProgress(viewPoints, t) {
+// Position along a polyline of already-view-space {cx, cy} points at time
+// fraction `t` (0..1), using each point's own recorded time rather than
+// constant speed by arc length — this is what makes playback "time
+// relative": a stretch of points recorded close together in time (the scout
+// drew that part of the path quickly) plays back quickly, and a stretch
+// recorded far apart in time (drawn slowly, e.g. a scoring action) plays
+// back slowly, regardless of how much on-field distance either covers.
+function markerAtTime(points, viewPoints, t) {
     if (viewPoints.length < 2) return viewPoints[0] ?? null;
 
-    const cumulative = [0];
-    for (let i = 1; i < viewPoints.length; i++) {
-        const dx = viewPoints[i].cx - viewPoints[i - 1].cx;
-        const dy = viewPoints[i].cy - viewPoints[i - 1].cy;
-        cumulative.push(cumulative[i - 1] + Math.hypot(dx, dy));
-    }
+    const times = points.map((p, i) => pointTime(p, i, points.length));
+    const clamped = Math.min(1, Math.max(0, t));
 
-    const total = cumulative[cumulative.length - 1];
-    if (total === 0) return viewPoints[0];
+    if (clamped <= times[0]) return viewPoints[0];
+    if (clamped >= times[times.length - 1]) return viewPoints[viewPoints.length - 1];
 
-    const targetDist = Math.min(t, 1) * total;
-    for (let i = 1; i < cumulative.length; i++) {
-        if (targetDist <= cumulative[i]) {
-            const segLen = cumulative[i] - cumulative[i - 1];
-            const segT = segLen === 0 ? 0 : (targetDist - cumulative[i - 1]) / segLen;
+    for (let i = 1; i < times.length; i++) {
+        if (clamped <= times[i]) {
+            const span = times[i] - times[i - 1];
+            const segT = span === 0 ? 0 : (clamped - times[i - 1]) / span;
             return {
                 cx: viewPoints[i - 1].cx + (viewPoints[i].cx - viewPoints[i - 1].cx) * segT,
                 cy: viewPoints[i - 1].cy + (viewPoints[i].cy - viewPoints[i - 1].cy) * segT
@@ -91,9 +103,39 @@ function markerAtProgress(viewPoints, t) {
     return viewPoints[viewPoints.length - 1];
 }
 
+// The fractional RANK (0..1 by point order, never by recorded time) that
+// time `t` currently falls at, given each point's own recorded time. This
+// is the inverse of "where in time is rank R" — used so the animated
+// marker's color always matches whichever fixed-rank-colored segment
+// (see gradientSegments below) it's currently passing through, even though
+// the time-to-rank mapping is exactly what timing edits change.
+function rankAtTime(points, t) {
+    const n = points.length;
+    if (n < 2) return 0;
+
+    const times = points.map((p, i) => pointTime(p, i, n));
+    const clamped = Math.min(1, Math.max(0, t));
+
+    if (clamped <= times[0]) return 0;
+    if (clamped >= times[n - 1]) return 1;
+
+    for (let i = 1; i < times.length; i++) {
+        if (clamped <= times[i]) {
+            const span = times[i] - times[i - 1];
+            const segT = span === 0 ? 0 : (clamped - times[i - 1]) / span;
+            const rankBefore = (i - 1) / (n - 1);
+            const rankAfter = i / (n - 1);
+            return rankBefore + (rankAfter - rankBefore) * segT;
+        }
+    }
+    return 1;
+}
+
 export default {
     props: {
         // Points in the [0,1] frame already resolved for the alliance/side being displayed.
+        // Each point is { x, y, t } — t is the point's own recorded time,
+        // in [0,1] fraction of the path's normalized duration (see pointTime in auto-path-field.ts).
         points: {
             type: Array,
             default: () => []
@@ -110,6 +152,15 @@ export default {
             type: String,
             default: "#ff8c00"
         },
+        // Renders the path as a rainbow gradient (red = start, violet = end)
+        // colored by fixed point order, instead of a flat `color` — used by
+        // the editor. Colored by order rather than recorded time so editing
+        // timing on the timeline below never repaints the path; the
+        // timeline shows how many seconds each fixed color takes instead.
+        timeGradient: {
+            type: Boolean,
+            default: false
+        },
         // Optional multi-path overlay: [{ key, points, color }]. When set,
         // this takes over rendering instead of the single `points`/`color` props.
         layers: {
@@ -123,10 +174,11 @@ export default {
             type: Boolean,
             default: false
         },
-        // When true, animates a robot marker traveling along the path(s) at
-        // constant speed, reaching the end after `duration` ms regardless of
-        // path length or point count. Parent owns this flag (play/stop button)
-        // and should reset it to false on the `finished` event.
+        // When true, animates a robot marker traveling along the path(s),
+        // reaching the end after `duration` ms regardless of path length or
+        // point count — but at each point's own recorded pace in between
+        // (time-relative, see markerAtTime above). Parent owns this flag
+        // (play/stop button) and should reset it to false on the `finished` event.
         playing: {
             type: Boolean,
             default: false
@@ -134,9 +186,16 @@ export default {
         duration: {
             type: Number,
             default: 20000
+        },
+        // Optional static "scrub" position (0..1): shows the marker at this
+        // time without running the play animation, for the timeline editor's
+        // scrub handle. Takes precedence over the play animation's progress.
+        previewProgress: {
+            type: Number,
+            default: null
         }
     },
-    emits: ["update:points", "finished"],
+    emits: ["update:points", "finished", "progress"],
     data() {
         return {
             VIEW_W,
@@ -144,7 +203,17 @@ export default {
             isDrawing: false,
             animProgress: 0,
             animStartTime: null,
-            animFrame: null
+            animFrame: null,
+            // Recording state for per-point timing while drawing (see
+            // pushPoint/resyncTimestamps below). Parallel array to
+            // displayPoints, holding each point's elapsed *active* drawing
+            // time in ms — paused while the pointer is lifted between
+            // strokes, since a lift is just a recording pause (see
+            // docs/auto-paths.md's "continuous-path drawing"), not something
+            // the robot actually did.
+            drawTimestamps: [],
+            accumulatedMs: 0,
+            strokeAnchorTime: null
         };
     },
     computed: {
@@ -154,10 +223,16 @@ export default {
         displayPoints() {
             return this.points ?? [];
         },
+        effectiveProgress() {
+            return this.previewProgress !== null ? this.previewProgress : this.animProgress;
+        },
+        showMarker() {
+            return this.playing || this.animProgress > 0 || this.previewProgress !== null;
+        },
         animatedMarker() {
-            if (this.hasLayers || this.animProgress === 0 && !this.playing) return null;
+            if (this.hasLayers || !this.showMarker) return null;
             if (this.displayPoints.length < 2) return null;
-            return markerAtProgress(this.displayPoints.map((p) => this.toView(p)), this.animProgress);
+            return markerAtTime(this.displayPoints, this.displayPoints.map((p) => this.toView(p)), this.effectiveProgress);
         },
         animatedLayerMarkers() {
             if (!this.hasLayers || this.animProgress === 0 && !this.playing) return [];
@@ -166,8 +241,38 @@ export default {
                 .map((layer) => ({
                     key: layer.key,
                     color: layer.color,
-                    marker: markerAtProgress(layer.points.map((p) => this.toView(p)), this.animProgress)
+                    marker: markerAtTime(layer.points, layer.points.map((p) => this.toView(p)), this.animProgress)
                 }));
+        },
+        // Colored by fixed RANK (point order), never by recorded time — so
+        // editing timing on the timeline never repaints the path: "the red
+        // part of the path" always means the same stretch of drawing. Only
+        // how many seconds that fixed-colored stretch takes (shown on the
+        // timeline, see AutoPathTimeline.vue) is editable.
+        gradientSegments() {
+            if (!this.timeGradient || this.displayPoints.length < 2) return [];
+            const view = this.displayPoints.map((p) => this.toView(p));
+            const len = this.displayPoints.length;
+
+            const segments = [];
+            for (let i = 1; i < len; i++) {
+                segments.push({
+                    x1: view[i - 1].cx,
+                    y1: view[i - 1].cy,
+                    x2: view[i].cx,
+                    y2: view[i].cy,
+                    color: pathTimeColor(((i - 1) / (len - 1) + i / (len - 1)) / 2)
+                });
+            }
+            return segments;
+        },
+        // The marker's color follows whichever fixed-rank-colored segment
+        // it's currently passing through in time, via rankAtTime — not the
+        // raw time progress, which would drift out of sync with the path's
+        // (fixed) coloring as soon as timing is edited to be non-uniform.
+        markerColorFraction() {
+            if (this.hasLayers || this.displayPoints.length < 2) return 0;
+            return rankAtTime(this.displayPoints, this.effectiveProgress);
         }
     },
     watch: {
@@ -203,6 +308,12 @@ export default {
                 return `${cx},${cy}`;
             }).join(" ");
         },
+        // Small fixed offset from a start/end marker so the label text
+        // doesn't sit directly on top of the dot.
+        labelPos(p) {
+            const { cx, cy } = this.toView(p);
+            return { x: cx + 6, y: cy - 6 };
+        },
         fromEvent(event) {
             const svg = this.$refs.svg;
             const rect = svg.getBoundingClientRect();
@@ -222,17 +333,50 @@ export default {
 
             return { x: fx, y: fy };
         },
+        // Re-syncs drawTimestamps with displayPoints whenever they've
+        // diverged — e.g. the parent reset the path (points -> []), or
+        // loaded an existing saved path (points -> its stored {x,y,t}s) —
+        // so a resumed/continued stroke keeps counting from a sensible
+        // elapsed time instead of a stale one. Existing points' timing is
+        // reconstructed from their stored `t` (scaled by `duration`, purely
+        // as an internal bookkeeping unit — everything gets re-normalized
+        // to [0,1] on the next point anyway).
+        resyncTimestamps() {
+            if (this.drawTimestamps.length !== this.displayPoints.length) {
+                this.drawTimestamps = this.displayPoints.map((p, i) => pointTime(p, i, this.displayPoints.length) * this.duration);
+            }
+            this.accumulatedMs = this.drawTimestamps.length > 0 ? this.drawTimestamps[this.drawTimestamps.length - 1] : 0;
+        },
+        // Appends one freshly-drawn raw {x,y} point, records its elapsed
+        // active-drawing time, and emits the whole path re-normalized so
+        // every point's `t` is a [0,1] fraction of the total drawing time so far.
+        pushPoint(rawPoint) {
+            const elapsed = this.strokeAnchorTime !== null
+                ? this.accumulatedMs + (performance.now() - this.strokeAnchorTime)
+                : this.accumulatedMs;
+            this.drawTimestamps = [...this.drawTimestamps, elapsed];
+
+            const maxMs = this.drawTimestamps[this.drawTimestamps.length - 1] || 0;
+            const newPoints = [...this.displayPoints.map((p) => ({ x: p.x, y: p.y })), rawPoint];
+            this.$emit("update:points", newPoints.map((p, i) => ({
+                x: p.x,
+                y: p.y,
+                t: maxMs > 0 ? this.drawTimestamps[i] / maxMs : (i === 0 ? 0 : 1)
+            })));
+        },
         onPointerDown(event) {
             if (!this.editable) return;
             event.preventDefault();
             this.isDrawing = true;
             this.$refs.svg.setPointerCapture?.(event.pointerId);
-            this.$emit("update:points", [...this.displayPoints, this.fromEvent(event)]);
+            this.resyncTimestamps();
+            this.strokeAnchorTime = performance.now();
+            this.pushPoint(this.fromEvent(event));
         },
         onPointerMove(event) {
             if (!this.editable || !this.isDrawing) return;
             event.preventDefault();
-            this.$emit("update:points", [...this.displayPoints, this.fromEvent(event)]);
+            this.pushPoint(this.fromEvent(event));
         },
         onPointerUp() {
             // Deliberately does NOT clear the point buffer: lifting the pointer
@@ -240,6 +384,10 @@ export default {
             // point array so the saved/rendered path is one continuous line
             // even if the scout's real-world drawing wasn't (see issue #14).
             this.isDrawing = false;
+            if (this.strokeAnchorTime !== null) {
+                this.accumulatedMs += performance.now() - this.strokeAnchorTime;
+                this.strokeAnchorTime = null;
+            }
         },
         startAnimation() {
             this.animProgress = 0;
@@ -251,6 +399,7 @@ export default {
 
                 const elapsed = timestamp - this.animStartTime;
                 this.animProgress = Math.min(1, elapsed / this.duration);
+                this.$emit("progress", this.animProgress);
 
                 if (this.animProgress < 1) {
                     this.animFrame = requestAnimationFrame(step);
@@ -303,6 +452,20 @@ export default {
 
 .path-start {
     stroke: none;
+}
+
+.path-end {
+    stroke: none;
+    opacity: 0.6;
+}
+
+.path-label {
+    font-size: 9px;
+    font-weight: 600;
+    fill: var(--primary-text-color, #fff);
+    stroke: var(--tile-background-color, #000);
+    stroke-width: 2px;
+    paint-order: stroke fill;
 }
 
 .path-robot {

--- a/src/components/AutoPathEditor.vue
+++ b/src/components/AutoPathEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 // @ts-nocheck
 import AutoPathCanvas from "@/components/AutoPathCanvas.vue";
+import AutoPathTimeline from "@/components/AutoPathTimeline.vue";
 import TextInput from "@/components/TextInput.vue";
 import Dropdown from "@/components/Dropdown.vue";
 
@@ -33,8 +34,19 @@ import "@material/web/button/filled-button";
                 </div>
             </div>
 
-            <AutoPathCanvas :points="points" :display-alliance="alliance" editable="true" large="true" color="#ff8c00"
-                @update:points="onPointsUpdate"></AutoPathCanvas>
+            <AutoPathCanvas :points="points" :display-alliance="alliance" editable="true" large="true"
+                time-gradient="true" :playing="isPlaying" :preview-progress="canvasPreviewProgress"
+                @update:points="onPointsUpdate" @finished="isPlaying = false"
+                @progress="scrubProgress = $event"></AutoPathCanvas>
+
+            <div class="autopath-preview-controls" v-if="points.length > 1">
+                <md-filled-button v-on:click="togglePlay" class="play-button">
+                    {{ isPlaying ? "■ STOP" : "▶ PLAY" }}
+                </md-filled-button>
+            </div>
+
+            <AutoPathTimeline v-if="points.length > 2" :points="points" :disabled="isPlaying"
+                v-model:scrub-progress="scrubProgress" @update:points="onPointsUpdate"></AutoPathTimeline>
 
             <div v-if="pathError" class="data-tile error-tile">Draw at least a couple of points before saving.</div>
 
@@ -79,6 +91,8 @@ export default {
             allianceIndex: 0,
             sideIndex: 0,
             points: [],
+            scrubProgress: 0,
+            isPlaying: false,
             nameError: false,
             pathError: false,
             isSubmitting: false,
@@ -93,6 +107,13 @@ export default {
         },
         side() {
             return this.SIDE_CHOICES[this.sideIndex]?.key ?? sideLeft;
+        },
+        // The scrub thumb only drives the marker while nothing is playing —
+        // otherwise it would permanently pin the marker at the scrub
+        // position (AutoPathCanvas treats any non-null previewProgress as
+        // taking priority over the play animation).
+        canvasPreviewProgress() {
+            return this.isPlaying ? null : this.scrubProgress;
         }
     },
     methods: {
@@ -118,6 +139,11 @@ export default {
         },
         resetPath() {
             this.points = [];
+            this.scrubProgress = 0;
+            this.isPlaying = false;
+        },
+        togglePlay() {
+            this.isPlaying = !this.isPlaying;
         },
         async save() {
             this.isSubmitting = true;
@@ -211,6 +237,11 @@ export default {
     align-items: center;
     gap: 10px;
     flex-wrap: wrap;
+}
+
+.autopath-preview-controls {
+    display: flex;
+    justify-content: flex-end;
 }
 
 .confirm-text {

--- a/src/components/AutoPathTimeline.vue
+++ b/src/components/AutoPathTimeline.vue
@@ -1,0 +1,427 @@
+<script setup lang="ts">
+// @ts-nocheck
+</script>
+
+<template>
+    <div class="autopath-timeline" :class="{ 'autopath-timeline--disabled': disabled }">
+        <div class="timeline-track" ref="track" @pointerdown="onTrackPointerDown" @pointermove="onTrackPointerMove"
+            @pointerup="onTrackPointerUp" @pointercancel="onTrackPointerUp" @dblclick="onTrackDoubleClick">
+            <!-- Each region spans exactly one draggable-bound-to-draggable-bound
+                 stretch — its left/width ARE the bounds' real-time positions
+                 (so width = seconds), but its color is fixed by point order
+                 (rank), the same fixed rainbow the canvas draws the path in
+                 above. So "red for 4 seconds" always means the same (red)
+                 stretch of the drawn path, just currently allotted 4 seconds
+                 of the auto; dragging a bound changes how many seconds each
+                 of its two neighboring regions get, never which color either
+                 region is. Regions tile the bar completely (no gaps), so a
+                 double-click anywhere lands inside exactly one and splits it. -->
+            <span v-for="region in regions" :key="region.key"
+                :style="{ left: `${region.left}%`, width: `${region.width}%`, background: region.background }"
+                class="timeline-region"></span>
+            <div class="timeline-scrub" :style="{ left: `${scrubProgress * 100}%` }"></div>
+            <!-- Draggable bounds sit at the border between two regions and
+                 resize both — a wide invisible hit area around a slim visible
+                 line, since a thin strip is much easier to land a drag on
+                 than a small floating dot was. Only interior bounds render;
+                 the two ends are the bar's own edges and aren't interactive. -->
+            <div v-for="(bound, idx) in interiorBounds" :key="bound.pointIndex" class="timeline-bound"
+                :style="{ left: `${bound.t * 100}%` }" @pointerdown="onBoundPointerDown(bound.handleIdx, $event)"
+                @pointermove="onBoundPointerMove(bound.handleIdx, $event)"
+                @pointerup="onBoundPointerUp(bound.handleIdx, $event)"
+                @pointercancel="onBoundPointerUp(bound.handleIdx, $event)"
+                @dblclick="onBoundDoubleClick(bound.handleIdx, $event)">
+                <span class="timeline-bound-line"></span>
+            </div>
+        </div>
+        <div class="timeline-ticks">
+            <span v-for="tick in tickSeconds" :key="tick.s" class="timeline-tick"
+                :class="{ 'timeline-tick--minor': !tick.major }" :style="{ left: `${(tick.s * 1000 / duration) * 100}%` }">
+                {{ tick.major ? `${tick.s}s` : '' }}
+            </span>
+        </div>
+        <p class="timeline-hint" v-if="!disabled">Drag the border between two colors to shrink or stretch
+            them — the far left and right edges are fixed so the whole auto still fits in
+            {{ Math.round(duration / 1000) }} seconds. Each color always marks the same stretch of the
+            drawn path (see the field above); dragging only changes how many seconds each stretch takes.
+            Double-click a color to split it into two, or double-click a border to remove it and merge
+            its two sides back together. Drag anywhere else on the bar to preview the robot's position
+            at that time.</p>
+        <p class="timeline-hint" v-else>Timing edits are paused while the path is playing — the white bar
+            tracks playback. Press stop to edit again.</p>
+    </div>
+</template>
+
+<script lang="ts">
+import { pointTime, pathTimeColor } from "@/lib/2026/auto-path-field";
+
+// How many regions the path starts out divided into. Exposing every raw
+// drawn point (there can be hundreds) as its own region would be an
+// unusable wall of slivers, so this is just the *initial* split — the scout
+// can split or merge regions from there (see onTrackDoubleClick/onBoundDoubleClick).
+const INITIAL_REGIONS = 10;
+
+// Rescales points[startIdx..endIdx]'s recorded time from the old
+// [oldStart, oldEnd] range into the new [newStart, newEnd] range, in place.
+function rescaleRange(points, startIdx, endIdx, oldStart, oldEnd, newStart, newEnd) {
+    const oldSpan = oldEnd - oldStart;
+    for (let i = startIdx; i <= endIdx; i++) {
+        const frac = oldSpan === 0 ? 0 : (points[i].t - oldStart) / oldSpan;
+        points[i].t = newStart + frac * (newEnd - newStart);
+    }
+}
+
+export default {
+    props: {
+        // Points in the same {x, y, t} shape as AutoPathCanvas.
+        points: {
+            type: Array,
+            default: () => []
+        },
+        duration: {
+            type: Number,
+            default: 20000
+        },
+        // Scrub position (0..1) — parent owns this so it can feed it
+        // straight into AutoPathCanvas's `previewProgress`.
+        scrubProgress: {
+            type: Number,
+            default: 0
+        },
+        // While true (the path is playing), bound dragging/split/merge and
+        // manual scrubbing are ignored — editing timing while the canvas is
+        // actively animating the same points out from under the edit was
+        // the source of the "glitchy, stuck" feeling; the parent instead
+        // drives `scrubProgress` itself from the canvas's own playback
+        // progress, so the white bar still tracks along in real time.
+        disabled: {
+            type: Boolean,
+            default: false
+        }
+    },
+    emits: ["update:points", "update:scrubProgress"],
+    data() {
+        return {
+            draggingHandleIdx: null,
+            isScrubbing: false,
+            // Point-array indices marking region boundaries. Always includes
+            // 0 and points.length-1 (the fixed start/end anchors) — every
+            // interior boundary is user-editable via double-click split/merge.
+            handleIndices: []
+        };
+    },
+    computed: {
+        // Every boundary (including the two fixed ends), positioned by its
+        // point's own recorded time. Used both to build `regions` and to
+        // drive drag math — `interiorBounds` below is the subset actually
+        // rendered as a draggable divider.
+        handles() {
+            const len = this.points.length;
+            return this.handleIndices.map((pointIndex) => ({
+                pointIndex,
+                t: pointTime(this.points[pointIndex], pointIndex, len),
+                fixed: pointIndex === 0 || pointIndex === len - 1
+            }));
+        },
+        // The draggable dividers — every boundary except the bar's own two
+        // outer edges, which have nothing to drag (there's no region beyond
+        // them). Keeps each entry's index into the full `handles` array
+        // (`handleIdx`) so drag handlers can look up prev/cur/next directly.
+        interiorBounds() {
+            return this.handles
+                .map((handle, handleIdx) => ({ ...handle, handleIdx }))
+                .filter((handle) => !handle.fixed);
+        },
+        // One colored, real-time-widthed box per region between consecutive
+        // boundaries — see the template comment for what left/width/color mean.
+        regions() {
+            const len = this.points.length;
+            const handles = this.handles;
+            if (handles.length < 2) return [];
+
+            // Each region is a gradient across its own rank span, not one
+            // flat midpoint color — a flat color only matches the canvas at
+            // the region's exact middle, drifting further off at the edges
+            // the wider the region is. Multiple stops (not just the two
+            // endpoints) because CSS gradients interpolate RGB linearly
+            // between stops, which drifts from pathTimeColor's HSL-based hue
+            // sweep over a wide span; several stops keep each inter-stop hop
+            // small enough that the difference is invisible. Adjacent
+            // regions share a boundary stop's exact color, so they meet with
+            // no visible seam.
+            const STOPS_PER_REGION = 4;
+            const regions = [];
+            for (let i = 1; i < handles.length; i++) {
+                const prev = handles[i - 1];
+                const cur = handles[i];
+                const stops = [];
+                for (let s = 0; s <= STOPS_PER_REGION; s++) {
+                    const pointIndex = prev.pointIndex + (cur.pointIndex - prev.pointIndex) * (s / STOPS_PER_REGION);
+                    const rank = len > 1 ? pointIndex / (len - 1) : 0;
+                    stops.push(pathTimeColor(rank));
+                }
+                regions.push({
+                    key: `${prev.pointIndex}-${cur.pointIndex}`,
+                    left: prev.t * 100,
+                    width: Math.max((cur.t - prev.t) * 100, 0),
+                    background: `linear-gradient(to right, ${stops.join(", ")})`
+                });
+            }
+            return regions;
+        },
+        // One tick per second (1-second resolution), with every 5th one
+        // labeled — labeling all of them would overlap.
+        tickSeconds() {
+            const totalSeconds = Math.round(this.duration / 1000);
+            const ticks = [];
+            for (let s = 0; s <= totalSeconds; s += 1) ticks.push({ s, major: s % 5 === 0 });
+            return ticks;
+        }
+    },
+    watch: {
+        // Re-seed the evenly-spaced default set whenever the point count
+        // changes. Points only ever change by appending (still drawing) or
+        // resetting to empty — never by inserting/reordering — so trying to
+        // remap old indices onto the new length is unnecessary work that,
+        // worse, compounds rounding error into collapsed/duplicate boundaries
+        // over the many small growth steps a single stroke fires. A custom
+        // split/merge only "sticks" once the scout has stopped drawing and
+        // the length stops changing — matching the normal
+        // draw-first-then-adjust-timing workflow.
+        "points.length"() {
+            this.seedHandleIndices();
+        },
+        // Cleanly bail out of any in-progress drag/scrub the instant playback
+        // starts, rather than leaving a stale pointer-captured drag hanging.
+        disabled(isDisabled) {
+            if (isDisabled) {
+                this.draggingHandleIdx = null;
+                this.isScrubbing = false;
+            }
+        }
+    },
+    created() {
+        this.seedHandleIndices();
+    },
+    methods: {
+        seedHandleIndices() {
+            const len = this.points.length;
+            if (len < 2) {
+                this.handleIndices = [];
+                return;
+            }
+            const regions = Math.min(INITIAL_REGIONS, len - 1);
+            const indices = new Set();
+            for (let k = 0; k <= regions; k++) {
+                indices.add(Math.round((k / regions) * (len - 1)));
+            }
+            this.handleIndices = [...indices].sort((a, b) => a - b);
+        },
+        tFromClientX(clientX) {
+            const rect = this.$refs.track.getBoundingClientRect();
+            const frac = rect.width === 0 ? 0 : (clientX - rect.left) / rect.width;
+            return Math.min(1, Math.max(0, frac));
+        },
+        // Splits whichever region the double-click landed in by adding a
+        // new boundary at the point nearest the clicked time.
+        onTrackDoubleClick(event) {
+            if (this.disabled || this.points.length < 2) return;
+            const target = this.tFromClientX(event.clientX);
+
+            let nearestIdx = 0;
+            let nearestDist = Infinity;
+            this.points.forEach((p, i) => {
+                const dist = Math.abs(pointTime(p, i, this.points.length) - target);
+                if (dist < nearestDist) {
+                    nearestDist = dist;
+                    nearestIdx = i;
+                }
+            });
+
+            if (this.handleIndices.includes(nearestIdx)) return;
+            this.handleIndices = [...this.handleIndices, nearestIdx].sort((a, b) => a - b);
+        },
+        // Removes a boundary the scout previously added (or one of the
+        // initial ones), merging the two regions on either side back into
+        // one — the two fixed end anchors can't be removed.
+        onBoundDoubleClick(handleIdx, event) {
+            event.stopPropagation();
+            if (this.disabled) return;
+            const handle = this.handles[handleIdx];
+            if (!handle || handle.fixed) return;
+            this.handleIndices = this.handleIndices.filter((idx) => idx !== handle.pointIndex);
+        },
+        onBoundPointerDown(handleIdx, event) {
+            if (this.disabled || this.handles[handleIdx].fixed) return;
+            event.stopPropagation();
+            event.preventDefault();
+            event.target.setPointerCapture?.(event.pointerId);
+            this.draggingHandleIdx = handleIdx;
+        },
+        onBoundPointerMove(handleIdx, event) {
+            if (this.draggingHandleIdx !== handleIdx) return;
+            event.stopPropagation();
+            this.dragHandleTo(handleIdx, this.tFromClientX(event.clientX));
+        },
+        onBoundPointerUp(handleIdx, event) {
+            if (this.draggingHandleIdx !== handleIdx) return;
+            event.stopPropagation();
+            event.target.releasePointerCapture?.(event.pointerId);
+            this.draggingHandleIdx = null;
+        },
+        dragHandleTo(handleIdx, rawT) {
+            const handles = this.handles;
+            const prev = handles[handleIdx - 1];
+            const next = handles[handleIdx + 1];
+            const cur = handles[handleIdx];
+            if (!prev || !next) return;
+
+            // Keeps every region at least this wide (as a fraction of the
+            // total duration, ~500ms) so requestAnimationFrame — which only
+            // samples animProgress every ~16ms — always gets several frames
+            // to render while playback passes through it. A region allowed
+            // to shrink arbitrarily thin (the old EPS = 0.001, ~20ms) could
+            // get only one or two rendered frames total, which reads as the
+            // marker teleporting rather than moving smoothly.
+            const MIN_REGION_T = 0.025;
+            // Guard against prev/next themselves already being closer
+            // together than 2*MIN_REGION_T (possible via double-click
+            // splits, which don't enforce this minimum) — clamping against
+            // both bounds normally in that case would let the lower bound
+            // win and push newT past prev.t, inverting the range.
+            const available = next.t - prev.t;
+            const newT = available <= MIN_REGION_T * 2
+                ? prev.t + available / 2
+                : Math.min(next.t - MIN_REGION_T, Math.max(prev.t + MIN_REGION_T, rawT));
+
+            const points = this.points.map((p, i) => ({ ...p, t: pointTime(p, i, this.points.length) }));
+            // The two ranges share cur.pointIndex as their common edge. The
+            // first call sets it to exactly newT; the second call must NOT
+            // also touch it — if it did, it would read that already-updated
+            // value back as its own "old" reference instead of the true
+            // original cur.t, scrambling both the boundary point's own
+            // saved time and every point after it (this was the actual bug
+            // behind saved timing not matching what was dragged to).
+            rescaleRange(points, prev.pointIndex, cur.pointIndex, prev.t, cur.t, prev.t, newT);
+            rescaleRange(points, cur.pointIndex + 1, next.pointIndex, cur.t, next.t, newT, next.t);
+
+            this.$emit("update:points", points);
+        },
+        onTrackPointerDown(event) {
+            if (this.disabled || this.draggingHandleIdx !== null) return;
+            event.target.setPointerCapture?.(event.pointerId);
+            this.isScrubbing = true;
+            this.$emit("update:scrubProgress", this.tFromClientX(event.clientX));
+        },
+        onTrackPointerMove(event) {
+            if (!this.isScrubbing) return;
+            this.$emit("update:scrubProgress", this.tFromClientX(event.clientX));
+        },
+        onTrackPointerUp(event) {
+            event.target.releasePointerCapture?.(event.pointerId);
+            this.isScrubbing = false;
+        }
+    }
+};
+</script>
+
+<style scoped>
+.autopath-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.timeline-track {
+    position: relative;
+    height: 28px;
+    touch-action: none;
+    cursor: pointer;
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.autopath-timeline--disabled .timeline-track {
+    cursor: default;
+}
+
+.autopath-timeline--disabled .timeline-bound {
+    cursor: default;
+    opacity: 0.4;
+}
+
+.timeline-region {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    opacity: 0.9;
+    pointer-events: none;
+}
+
+.timeline-scrub {
+    position: absolute;
+    top: -3px;
+    bottom: -3px;
+    width: 2px;
+    background: var(--primary-text-color);
+    transform: translateX(-50%);
+    pointer-events: none;
+}
+
+/* A wide invisible hit area centered on the boundary, with a slim visible
+   line in the middle — much easier to land a drag on than a small dot. */
+.timeline-bound {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: translateX(-50%);
+    cursor: ew-resize;
+    touch-action: none;
+}
+
+.timeline-bound-line {
+    width: 3px;
+    height: 100%;
+    background: var(--primary-text-color);
+    border-radius: 2px;
+    opacity: 0.85;
+    pointer-events: none;
+}
+
+.timeline-bound:hover .timeline-bound-line {
+    opacity: 1;
+    width: 4px;
+}
+
+.timeline-ticks {
+    position: relative;
+    height: 14px;
+}
+
+.timeline-tick {
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    font-size: 10px;
+    opacity: 0.6;
+    white-space: nowrap;
+}
+
+.timeline-tick--minor {
+    top: 1px;
+    width: 1px;
+    height: 5px;
+    background: var(--primary-text-color);
+    opacity: 0.35;
+}
+
+.timeline-hint {
+    font-size: 0.85em;
+    opacity: 0.75;
+    margin: 4px 0 0;
+}
+</style>

--- a/src/lib/2026/auto-path-field.ts
+++ b/src/lib/2026/auto-path-field.ts
@@ -20,6 +20,9 @@ import { allianceRed, allianceBlue, sideLeft, sideRight } from "@/lib/constants"
 export interface FieldPoint {
     x: number;
     y: number;
+    // Recorded time, [0,1] fraction of the path's normalized duration.
+    // Optional — absent on paths saved before per-point timing existed.
+    t?: number;
 }
 
 export const ALLIANCE_CHOICES = [
@@ -39,8 +42,30 @@ export const SIDE_CHOICES = [
  */
 export function transformPath(points: FieldPoint[], fromSide: string, toSide: string): FieldPoint[] {
     if (fromSide === toSide) {
-        return points.map((p) => ({ x: p.x, y: p.y }));
+        return points.map((p) => ({ ...p }));
     }
 
-    return points.map((p) => ({ x: p.x, y: 1 - p.y }));
+    return points.map((p) => ({ ...p, y: 1 - p.y }));
+}
+
+/**
+ * A point's recorded time, in [0,1] fraction of the path's normalized
+ * duration. Points saved before per-point timing existed have no `.t` —
+ * fall back to even spacing by index so old paths still animate (constant
+ * speed) instead of breaking.
+ */
+export function pointTime(point: FieldPoint, index: number, count: number): number {
+    if (typeof point.t === "number") return point.t;
+    return count > 1 ? index / (count - 1) : 0;
+}
+
+/**
+ * Red (t=0, path start) -> violet (t=1, path end) — the rainbow used to
+ * color a path by recorded time, shared by the canvas's gradient rendering
+ * and the timeline editor so the two always agree on what a given time
+ * "looks like".
+ */
+export function pathTimeColor(t: number): string {
+    const hue = Math.min(1, Math.max(0, t)) * 270;
+    return `hsl(${hue}, 85%, 50%)`;
 }


### PR DESCRIPTION
Records each drawn point's own elapsed time and plays it back time-relative instead of at constant speed, so fast/slow stretches of a drawn auto keep their real pacing. The editor renders the path as a fixed-by-rank rainbow gradient with a resizable-region timeline below it for adjusting how many seconds each color takes, plus play/scrub preview wired between the two.


Closes #35 