### PR TITLE
Improve unranked picklist UX (issue #34)

### DIFF
--- a/docs/picklist.md
+++ b/docs/picklist.md
@@ -32,6 +32,92 @@ Navigate to **Pick List** in the nav bar (or go to `/picklist`). You must be log
 
 On the **My List** or **Team List** tab, drag the `⠿` handle on the left of any row to change that team's rank. Click **Save List** when finished.
 
+### Unranked Teams ([issue #34](https://github.com/Team973/greyscout/issues/34))
+
+Teams with no tier assigned yet live in the **Unranked** section, rendered
+separately from the ranked tiers (S through DNP) rather than as just another
+row list:
+- **Layout**: on desktop (≥1000px, same breakpoint as the app-wide
+  `isMobile`/`minWidthForDesktop` switch — bumped from 820px to 1000px
+  alongside this issue, since the desktop nav bar's item count no longer
+  fit below that width; see `src/lib/constants.ts`), ranked tiers stack in
+  a left column and
+  Unranked renders in a fixed-width (360px) column on the right, so the
+  two are visible side by side while sorting; below that width both stack
+  vertically, Unranked last — same as before.
+- **Card style**: each unranked team is a big square grid card
+  (`PicklistUnrankedCard.vue`); collapsed it shows only the robot photo,
+  team number, and watchlist star — deliberately less information than a
+  ranked row (no name, tier-vote stats, or picked checkbox), since the
+  point of this view is fast visual triage of a large untriaged pool.
+  Cards render **exactly 3 per row** (`.unranked-grid` is `display: flex;
+  flex-wrap: wrap` with each card at `flex: 0 0 calc((100% - 20px) / 3)` —
+  deliberately *not* CSS `display: grid`, see the SortableJS gotcha below).
+  The collapsed photo uses `object-fit: contain` (not `cover`) so the full
+  robot is always visible rather than cropped by the team-number bar below
+  it.
+- **Drag-and-drop still works both ways**: the Unranked grid is a
+  `vuedraggable` list in the same `group="picklist"` as every ranked tier,
+  so a team can be dragged from Unranked into any tier, or dragged back
+  out of a tier into Unranked, exactly like dragging between two ranked
+  tiers. Drag starts from a small `⠿` handle badge in the card's top-left
+  corner (`handle=".unranked-card-handle"`, matching the `handle` pattern
+  the other 6 tier lists already use) — clicking the rest of the card
+  instead expands it (see below).
+- **Clicking a card** (anywhere but the handle/watch star) expands it to a
+  roughly 3×3-card footprint showing the full photo, name, aggregated match
+  stats, and scout comments — the same data a ranked row's expanded view
+  shows. Click again to collapse.
+- **Gotcha #1**: the card's `<img>` must have `draggable="false"` — without
+  it, starting a pointer-drag on top of the photo (which fills most of the
+  square) can be hijacked by the browser's own native image-drag-out
+  gesture instead of being picked up by SortableJS's fallback drag
+  handling, silently preventing the card from ever starting a sortable
+  drag. Ranked rows never hit this because their drag handle is a small
+  text/emoji span (`.picklist-drag-handle`), never the photo itself.
+- **Gotcha #2 — the real cause of "drag from Unranked doesn't stick, and
+  then no list drags at all"**: `PicklistUnrankedCard.vue`'s template used
+  to open with a template-level HTML comment placed *before* the root
+  `<div class="unranked-card">`. Vue compiles a component template with a
+  comment as a root-level sibling into a **fragment root** (comment node +
+  div, joined by whitespace text nodes), not a single element. vuedraggable
+  captures each list item's `vnode.el` to attach `__draggable_context` (the
+  data its `onDragStart` reads via `getUnderlyingVm`) — for a fragment
+  root, that `.el` is the fragment's anchor node, not the real card div, so
+  every Unranked card silently ended up with no drag context at all.
+  Starting *any* drag on *any* Unranked card (same-list reorder or
+  cross-list) then threw `Cannot read properties of null (reading
+  'element')` inside vuedraggable's internal `onDragStart`, before it ever
+  reached the point of moving the item or emitting `@start` — which is why
+  the move never stuck, autoscroll (driven off `@start`/`@end`, see
+  `PicklistView.vue`) never kicked in, and the exception corrupted
+  vuedraggable's shared module-level drag state badly enough that every
+  other list on the page stopped responding to drags too, until reload.
+  **The fix — and the rule going forward — is that a component with a
+  single-root template used inside a `vuedraggable` `#item` slot must
+  never have a comment (or any other node) as a template-level sibling of
+  that root**; put explanatory comments in the `<script>` block instead.
+- **Gotcha #3**: a card's
+  width comes from `PicklistView.vue`'s `.unranked-grid > .unranked-card`
+  rule, which only matches while the card is an actual DOM child of
+  `.unranked-grid`. But cross-list dragging in the same SortableJS `group`
+  doesn't just show a visual clone — it **actually moves the real dragged
+  element** into whichever list you're currently hovering over, live, as
+  part of previewing the drop position. The instant it's moved into a
+  ranked tier's `.tier-section-body` (a `flex-direction: column` list whose
+  children stretch to full width by default), the parent-scoped width rule
+  stops matching, the card has no width of its own, and `aspect-ratio: 1`
+  blows its height up to match — visually, the dragged photo balloons to
+  fill almost the entire tier column while dragging. The fix is a
+  self-contained fallback `max-width: 140px` directly on `.unranked-card`
+  in `PicklistUnrankedCard.vue` itself (lower priority than the parent's
+  grid rule via specificity, so it only kicks in once the card has actually
+  left `.unranked-grid`). This is also why the section briefly considered
+  and reverted CSS `display: grid` for the layout instead of `flex-wrap`:
+  grid was a red herring — the size-loses-on-reparent bug reproduced either
+  way, and flex-wrap is also just more predictable with SortableJS's
+  index/swap math in general.
+
 ### Expanding a Team Row
 
 Tap or click any team row to expand it. The expanded view shows:
@@ -114,7 +200,8 @@ See [users.md](./users.md) for the full `User` table schema, roles, and role-man
 
 | File | Purpose |
 |---|---|
-| [`src/views/PicklistView.vue`](../src/views/PicklistView.vue) | Main picklist page — tabs, draggable list, expand/collapse |
+| [`src/views/PicklistView.vue`](../src/views/PicklistView.vue) | Main picklist page — tabs, draggable list, expand/collapse, the desktop two-column ranked/Unranked layout |
+| [`src/components/PicklistUnrankedCard.vue`](../src/components/PicklistUnrankedCard.vue) | Big square grid card for the Unranked section — collapsed shows photo/number/watch-star, click to expand to full stats/comments; drag via the `⠿` handle badge |
 | [`src/stores/picklist-store.ts`](../src/stores/picklist-store.ts) | Pinia store: list state, CRUD actions, democratic computation |
 | [`src/lib/picklist-query.ts`](../src/lib/picklist-query.ts) | All Supabase queries for the picklist feature |
 | [`src/stores/offline-queue-store.ts`](../src/stores/offline-queue-store.ts) | Persistent offline save queue (localStorage) |

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -14,7 +14,7 @@ import { useOfflineQueueStore } from "@/stores/offline-queue-store";
 
 <template>
     <!-- Mobile navigation bar (hamburger menu) -->
-    <div class="nav" v-if="viewMode?.isMobile && isLoggedIn">
+    <div class="nav" :class="{ 'nav--hidden': navHidden }" v-if="viewMode?.isMobile && isLoggedIn">
         <HamburgerMenu>
             <template v-slot:menu-title>
                 {{ eventName }}
@@ -41,7 +41,7 @@ import { useOfflineQueueStore } from "@/stores/offline-queue-store";
         </HamburgerMenu>
 
     </div>
-    <div class="nav" v-else-if="viewMode?.isMobile && !isLoggedIn">
+    <div class="nav" :class="{ 'nav--hidden': navHidden }" v-else-if="viewMode?.isMobile && !isLoggedIn">
         <HamburgerMenu>
             <template v-slot:menu-title>
                 <RouterLink to="/" class="nav-link">GreyScout</RouterLink>
@@ -58,7 +58,7 @@ import { useOfflineQueueStore } from "@/stores/offline-queue-store";
             </template>
         </HamburgerMenu>
     </div>
-    <div class="nav" v-else-if="!viewMode?.isMobile && isLoggedIn">
+    <div class="nav" :class="{ 'nav--hidden': navHidden }" v-else-if="!viewMode?.isMobile && isLoggedIn">
         <!-- <RouterLink to="/upload" class="nav-link" v-if="isWriteAccess">Data Upload</RouterLink> -->
         <RouterLink to="/schedule" class="nav-link">Schedule</RouterLink>
         <RouterLink to="/match" class="nav-link">Match Scouting</RouterLink>
@@ -82,7 +82,7 @@ import { useOfflineQueueStore } from "@/stores/offline-queue-store";
             <md-icon slot="icon" v-else>account_circle</md-icon>
         </div>
     </div>
-    <div class="nav" v-else>
+    <div class="nav" :class="{ 'nav--hidden': navHidden }" v-else>
         <RouterLink to="/" class="nav-link">GreyScout</RouterLink>
 
         <div class="nav-dark-mode nav-right" @click="userLogin">
@@ -112,7 +112,12 @@ export default {
             eventStore: null,
             authStore: null,
             queueStore: null,
-            isOnline: navigator.onLine
+            isOnline: navigator.onLine,
+            // Hidden while scrolling down, shown again while scrolling up —
+            // see handleScroll below.
+            navHidden: false,
+            lastScrollTop: 0,
+            scrollContainer: null
         }
     },
     created() {
@@ -126,6 +131,16 @@ export default {
 
         window.addEventListener('online', () => { this.isOnline = true; });
         window.addEventListener('offline', () => { this.isOnline = false; });
+    },
+    mounted() {
+        // The whole SPA scrolls inside #app (position: fixed + overflow:
+        // auto in main.css), not the window — window scroll events never
+        // fire here, so the listener has to target #app directly.
+        this.scrollContainer = document.getElementById('app') || document.scrollingElement || document.documentElement;
+        this.scrollContainer.addEventListener('scroll', this.handleScroll, { passive: true });
+    },
+    beforeUnmount() {
+        this.scrollContainer?.removeEventListener('scroll', this.handleScroll);
     },
     computed: {
         eventName() {
@@ -142,6 +157,26 @@ export default {
         }
     },
     methods: {
+        // Hides the nav while scrolling down (past its own height, so it
+        // never hides right at the top of a short page), shows it again on
+        // any scroll up — a small dead zone (SCROLL_DELTA) ignores jitter
+        // from momentum/rubber-band scrolling so it doesn't flicker.
+        handleScroll() {
+            const SCROLL_DELTA = 4;
+            const NAV_HEIGHT = 65;
+            const scrollTop = Math.max(0, this.scrollContainer.scrollTop);
+            const delta = scrollTop - this.lastScrollTop;
+
+            if (scrollTop <= NAV_HEIGHT) {
+                this.navHidden = false;
+            } else if (delta > SCROLL_DELTA) {
+                this.navHidden = true;
+            } else if (delta < -SCROLL_DELTA) {
+                this.navHidden = false;
+            }
+
+            this.lastScrollTop = scrollTop;
+        },
         toggleUserDarkMode() {
             this.viewMode.toggleUserDarkMode();
         },
@@ -169,6 +204,12 @@ div.nav {
     height: 65px;
     position: fixed;
     display: block;
+    transform: translateY(0);
+    transition: transform 0.3s ease;
+}
+
+div.nav.nav--hidden {
+    transform: translateY(-100%);
 }
 
 

--- a/src/components/PicklistRow.vue
+++ b/src/components/PicklistRow.vue
@@ -2,6 +2,7 @@
 // @ts-nocheck
 import type { TeamEntry } from '@/stores/picklist-store';
 import type { TeamTierStats } from '@/lib/picklist-query';
+import { computeBasicStats, computeFlagStats } from '@/lib/picklist-stats';
 
 defineProps<{
     rowId: string;
@@ -22,50 +23,6 @@ defineProps<{
 }>();
 
 const emit = defineEmits(['toggle-expand', 'toggle-picked', 'toggle-watch']);
-
-function computeBasicStats(matchData: unknown[]) {
-    if (!matchData.length) return [];
-
-    // Derive numeric fields automatically from the first row
-    const numericFields: string[] = [];
-    if (matchData[0]) {
-        Object.entries(matchData[0]).forEach(([key, val]) => {
-            if (typeof val === 'number' && !key.includes('match_number') && !key.includes('team_number')) {
-                numericFields.push(key);
-            }
-        });
-    }
-
-    return numericFields.slice(0, 8).map((field) => {
-        const values = matchData.map(row => row[field]).filter(v => typeof v === 'number');
-        const avg = values.length ? (values.reduce((a, b) => a + b, 0) / values.length) : 0;
-        const max = values.length ? Math.max(...values) : 0;
-        return { label: formatFieldLabel(field), avg: avg.toFixed(1), max };
-    });
-}
-
-function formatFieldLabel(field: string) {
-    return field
-        .replace(/^(prematch_|postmatch_|auto_|teleop_|endgame_)/g, '')
-        .replace(/_/g, ' ')
-        .replace(/\b\w/g, c => c.toUpperCase());
-}
-
-const FLAG_STATS = [
-    { key: 'postmatch_broke', label: 'Break %' },
-    { key: 'postmatch_died', label: 'Die %' },
-    { key: 'postmatch_beached', label: 'Beach %' },
-    { key: 'postmatch_played_defense', label: 'Defense %' }
-];
-
-function computeFlagStats(matchData: unknown[]) {
-    if (!matchData.length) return [];
-    return FLAG_STATS.map(({ key, label }) => {
-        const count = matchData.filter(row => !!row[key]).length;
-        const pct = (count / matchData.length) * 100;
-        return { label, pct: pct.toFixed(0), count, total: matchData.length };
-    });
-}
 
 function formatAvgRank(avgRank: number) {
     return avgRank.toFixed(1);

--- a/src/components/PicklistUnrankedCard.vue
+++ b/src/components/PicklistUnrankedCard.vue
@@ -1,0 +1,376 @@
+<script setup lang="ts">
+// @ts-nocheck
+import type { TeamEntry } from '@/stores/picklist-store';
+import { computeBasicStats, computeFlagStats } from '@/lib/picklist-stats';
+
+defineProps<{
+    rowId: string;
+    team: TeamEntry;
+    watched: boolean;
+    canToggleWatch: boolean;
+    expanded: boolean;
+    expandedData: { stats: unknown[]; comments: unknown[] } | null;
+    expandedLoading: boolean;
+}>();
+
+const emit = defineEmits(['toggle-watch', 'toggle-expand']);
+
+// A template-level HTML comment placed before the root element compiles to
+// a fragment root (comment node + div), which breaks vuedraggable — it
+// captures the fragment anchor as the card's DOM element instead of the
+// real div, so `__draggable_context` never attaches. Keep this component's
+// template to a single root node; put comments here instead.
+</script>
+
+<template>
+    <div class="unranked-card" :class="{ 'unranked-card--expanded': expanded }" :id="rowId"
+        @click="emit('toggle-expand')">
+        <div class="unranked-card-handle" @click.stop title="Drag to reorder">⠿</div>
+        <button v-if="watched || canToggleWatch" type="button" class="unranked-card-watch"
+            :class="{ 'unranked-card-watch--active': watched }" :disabled="!canToggleWatch"
+            @click.stop="canToggleWatch && emit('toggle-watch')"
+            :title="canToggleWatch ? (watched ? 'Remove from watchlist' : 'Add to watchlist') : 'On the watchlist'">
+            ★
+        </button>
+
+        <template v-if="!expanded">
+            <div class="unranked-card-photo">
+                <img v-if="team.photo_url" :src="team.photo_url" :alt="`Team ${team.team_number} robot`" loading="lazy"
+                    draggable="false" />
+                <div v-else class="unranked-card-placeholder">
+                    <span>🤖</span>
+                </div>
+            </div>
+            <div class="unranked-card-number">{{ team.team_number }}</div>
+        </template>
+
+        <template v-else>
+            <div class="unranked-card-expanded-header">
+                <div class="unranked-card-photo-lg">
+                    <img v-if="team.photo_url" :src="team.photo_url" :alt="`Team ${team.team_number} robot`"
+                        draggable="false" />
+                    <div v-else class="unranked-card-placeholder">
+                        <span>🤖</span>
+                    </div>
+                </div>
+                <div class="unranked-card-number-lg">{{ team.team_number }}</div>
+                <div class="unranked-card-name-lg">{{ team.name }}</div>
+            </div>
+
+            <div v-if="expandedLoading" class="unranked-card-detail-loading">
+                <div class="unranked-card-spinner"></div> Loading data…
+            </div>
+            <div v-else-if="expandedData" class="unranked-card-detail-content" @click.stop>
+                <div v-if="expandedData.stats.length > 0" class="unranked-card-stats-grid">
+                    <div v-for="stat in computeFlagStats(expandedData.stats)" :key="stat.label"
+                        class="unranked-card-stat">
+                        <div class="stat-label">{{ stat.label }}</div>
+                        <div class="stat-avg">{{ stat.pct }}%</div>
+                    </div>
+                    <div v-for="stat in computeBasicStats(expandedData.stats)" :key="stat.label"
+                        class="unranked-card-stat">
+                        <div class="stat-label">{{ stat.label }}</div>
+                        <div class="stat-avg">{{ stat.avg }}</div>
+                    </div>
+                </div>
+                <div v-else class="unranked-card-no-data">No match data available.</div>
+
+                <ul v-if="expandedData.comments.length > 0" class="unranked-card-comments">
+                    <li v-for="(comment, idx) in expandedData.comments" :key="idx" class="unranked-card-comment">
+                        <div class="comment-meta">
+                            <span class="comment-author">{{ comment.author }}</span>
+                            <span class="comment-source-badge">{{ comment.source }}</span>
+                        </div>
+                        <p class="comment-text">{{ comment.comment }}</p>
+                    </li>
+                </ul>
+            </div>
+        </template>
+    </div>
+</template>
+
+<style scoped>
+.unranked-card {
+    position: relative;
+    /* Self-contained fallback size — PicklistView.vue's own
+       `.unranked-grid > .unranked-card` rule normally overrides this
+       (higher specificity) to give exactly 3 per row. But SortableJS
+       temporarily re-parents the actual dragged element into whichever
+       list it's currently hovering over (that's how the live drop-position
+       preview works for a cross-list drag, not just a visual clone) — the
+       moment it leaves .unranked-grid, that parent-scoped rule stops
+       matching. Without an intrinsic width of its own here, the card then
+       defaults to stretching to fill the much wider ranked-tier column
+       (a flex-direction: column list, whose children stretch to full
+       width by default), and aspect-ratio: 1 blows the height up to
+       match — a real bug (seen as the photo rendering huge and stretched
+       mid-drag), not just an automation-testing artifact.
+       See docs/picklist.md's "Unranked Teams" section. */
+    max-width: 140px;
+    aspect-ratio: 1;
+    display: flex;
+    flex-direction: column;
+    background: var(--tile-background-color);
+    border-radius: 12px;
+    overflow: hidden;
+    user-select: none;
+    cursor: pointer;
+    box-shadow:
+        inset 0 0 0.5px 1px hsla(0, 0%, 100%, 0.07),
+        0 1px 4px hsla(230, 13%, 9%, 0.07),
+        0 2px 10px hsla(230, 13%, 9%, 0.06);
+    transition: box-shadow 0.2s ease;
+}
+
+/* Roughly a 3x3-card footprint: full row width instead of 1/3, and a
+   generous min-height instead of the collapsed aspect-ratio: 1 square, so
+   the photo/stats/comments below have room. */
+.unranked-card--expanded {
+    max-width: 100%;
+    flex: 1 1 100%;
+    aspect-ratio: auto;
+    min-height: 380px;
+    cursor: default;
+    padding: 14px;
+    gap: 10px;
+    box-shadow:
+        0 0 0 2px #b05703,
+        0 4px 20px hsla(230, 13%, 9%, 0.14);
+}
+
+.unranked-card--ghost {
+    opacity: 0.45;
+}
+
+.unranked-card:hover {
+    box-shadow:
+        inset 0 0 0.5px 1px hsla(0, 0%, 100%, 0.1),
+        0 2px 8px hsla(230, 13%, 9%, 0.12),
+        0 4px 16px hsla(230, 13%, 9%, 0.1);
+}
+
+.unranked-card-handle {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    z-index: 1;
+    color: rgba(255, 255, 255, 0.75);
+    background: rgba(0, 0, 0, 0.45);
+    border-radius: 6px;
+    padding: 1px 4px;
+    font-size: 13px;
+    line-height: 1.4;
+    cursor: grab;
+}
+
+.unranked-card-photo {
+    flex: 1;
+    min-height: 0;
+    background: rgba(128, 128, 128, 0.1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.unranked-card-photo img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.unranked-card-placeholder {
+    font-size: 32px;
+}
+
+.unranked-card-number {
+    flex-shrink: 0;
+    text-align: center;
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--primary-text-color);
+    padding: 6px 4px;
+}
+
+.unranked-card-watch {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    z-index: 1;
+    background: rgba(0, 0, 0, 0.45);
+    border: none;
+    border-radius: 6px;
+    padding: 2px 5px;
+    font-size: 16px;
+    line-height: 1.2;
+    color: rgba(255, 255, 255, 0.7);
+    cursor: pointer;
+    transition: color 0.15s ease, transform 0.1s ease;
+}
+
+.unranked-card-watch:not(:disabled):hover {
+    color: #e0b400;
+    transform: scale(1.1);
+}
+
+.unranked-card-watch--active {
+    color: #e0b400;
+}
+
+.unranked-card-watch:disabled {
+    cursor: default;
+}
+
+/* ── Expanded content ── */
+.unranked-card-expanded-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding-top: 22px;
+}
+
+.unranked-card-photo-lg {
+    width: 100%;
+    max-width: 220px;
+    aspect-ratio: 4 / 3;
+    border-radius: 10px;
+    overflow: hidden;
+    background: rgba(128, 128, 128, 0.1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.unranked-card-photo-lg img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.unranked-card-number-lg {
+    font-size: 20px;
+    font-weight: 800;
+    color: var(--primary-text-color);
+    margin-top: 8px;
+}
+
+.unranked-card-name-lg {
+    font-size: 13px;
+    color: rgba(128, 128, 128, 0.8);
+}
+
+.unranked-card-detail-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    font-size: 13px;
+    color: rgba(128, 128, 128, 0.7);
+    padding: 8px 0;
+}
+
+.unranked-card-spinner {
+    width: 20px;
+    height: 20px;
+    border: 2px solid rgba(176, 87, 3, 0.2);
+    border-top-color: #b05703;
+    border-radius: 50%;
+    animation: unranked-card-spin 0.8s linear infinite;
+}
+
+@keyframes unranked-card-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.unranked-card-detail-content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    cursor: default;
+}
+
+.unranked-card-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+    gap: 8px;
+}
+
+.unranked-card-stat {
+    background: rgba(176, 87, 3, 0.08);
+    border: 1px solid rgba(176, 87, 3, 0.2);
+    border-radius: 8px;
+    padding: 6px 8px;
+    text-align: center;
+}
+
+.stat-label {
+    font-size: 10px;
+    color: rgba(128, 128, 128, 0.75);
+    margin-bottom: 2px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.stat-avg {
+    font-size: 16px;
+    font-weight: 700;
+    color: #b05703;
+    line-height: 1.1;
+}
+
+.unranked-card-no-data {
+    font-size: 13px;
+    color: rgba(128, 128, 128, 0.6);
+    font-style: italic;
+}
+
+.unranked-card-comments {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.unranked-card-comment {
+    border: 1px solid rgba(128, 128, 128, 0.2);
+    border-radius: 8px;
+    padding: 8px 10px;
+}
+
+.comment-meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+    flex-wrap: wrap;
+}
+
+.comment-author {
+    font-weight: 700;
+    font-size: 12px;
+    color: var(--primary-text-color);
+}
+
+.comment-source-badge {
+    font-size: 9px;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: 20px;
+    background: rgba(176, 87, 3, 0.15);
+    color: #b05703;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.comment-text {
+    font-size: 12px;
+    color: var(--primary-text-color);
+    line-height: 1.5;
+    margin: 0;
+}
+</style>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -52,4 +52,4 @@ export const useDefaultEvent = true;
 
 
 // View mode options.
-export const minWidthForDesktop = 820;
+export const minWidthForDesktop = 1000;

--- a/src/lib/picklist-stats.ts
+++ b/src/lib/picklist-stats.ts
@@ -1,0 +1,49 @@
+// @ts-nocheck
+// Shared expanded-detail stat computation, used by both PicklistRow.vue and
+// PicklistUnrankedCard.vue's expanded views so the two don't duplicate the
+// same field-derivation logic.
+
+export function computeBasicStats(matchData: unknown[]) {
+    if (!matchData.length) return [];
+
+    // Derive numeric fields automatically from the first row
+    const numericFields: string[] = [];
+    if (matchData[0]) {
+        Object.entries(matchData[0]).forEach(([key, val]) => {
+            if (typeof val === 'number' && key !== 'id' && !key.includes('match_number') && !key.includes('team_number')) {
+                numericFields.push(key);
+            }
+        });
+    }
+
+    return numericFields.slice(0, 8).map((field) => {
+        const values = matchData.map(row => row[field]).filter(v => typeof v === 'number');
+        const avg = values.length ? (values.reduce((a, b) => a + b, 0) / values.length) : 0;
+        const max = values.length ? Math.max(...values) : 0;
+        return { label: formatFieldLabel(field), avg: avg.toFixed(1), max };
+    });
+}
+
+export function formatFieldLabel(field: string) {
+    return field
+        .replace(/^(prematch_|postmatch_|auto_|teleop_|endgame_)/g, '')
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+export const FLAG_STATS = [
+    { key: 'auto_failed', label: 'Auto Fail %' },
+    { key: 'postmatch_broke', label: 'Break %' },
+    { key: 'postmatch_died', label: 'Die %' },
+    { key: 'postmatch_beached', label: 'Beach %' },
+    { key: 'postmatch_played_defense', label: 'Defense %' }
+];
+
+export function computeFlagStats(matchData: unknown[]) {
+    if (!matchData.length) return [];
+    return FLAG_STATS.map(({ key, label }) => {
+        const count = matchData.filter(row => !!row[key]).length;
+        const pct = (count / matchData.length) * 100;
+        return { label, pct: pct.toFixed(0), count, total: matchData.length };
+    });
+}

--- a/src/views/PicklistView.vue
+++ b/src/views/PicklistView.vue
@@ -8,8 +8,9 @@ import { useAuthStore } from '@/stores/auth-store';
 import { useEventStore } from '@/stores/event-store';
 import { useOfflineQueueStore } from '@/stores/offline-queue-store';
 import { useWatchlistStore } from '@/stores/watchlist-store';
-import { TIER_GROUPS } from '@/lib/picklist-query';
+import { TIERS, TIER_GROUPS } from '@/lib/picklist-query';
 import PicklistRow from '@/components/PicklistRow.vue';
+import PicklistUnrankedCard from '@/components/PicklistUnrankedCard.vue';
 
 const picklistStore = usePicklistStore();
 const authStore = useAuthStore();
@@ -384,25 +385,44 @@ function toggleTierCollapse(group: string) {
                     <p>No personal lists have been submitted yet — submit yours on the "My List" tab first.</p>
                 </div>
 
-                <!-- Tier-grouped sections -->
-                <div v-else class="tier-sections">
-                    <div v-for="group in TIER_GROUPS" :key="group" class="tier-section">
-                        <div class="tier-section-header" :class="`tier-section-header--${group}`"
-                            @click="toggleTierCollapse(group)">
-                            <span class="tier-section-collapse-icon"
-                                :class="{ 'tier-section-collapse-icon--collapsed': isTierCollapsed(group) }">▾</span>
-                            <span class="tier-section-name">{{ tierGroupLabel(group) }}</span>
-                            <span class="tier-section-count">{{ (picklistStore.activeSections[group] || []).length }}</span>
-                        </div>
+                <!-- Tier-grouped sections: ranked tiers on the left, the
+                     Unranked pool (bigger grid squares — photo/number/watch
+                     only) on the right on desktop, stacked below on mobile. -->
+                <div v-else class="picklist-columns">
+                    <div class="tier-sections-ranked">
+                        <div v-for="group in TIERS" :key="group" class="tier-section">
+                            <div class="tier-section-header" :class="`tier-section-header--${group}`"
+                                @click="toggleTierCollapse(group)">
+                                <span class="tier-section-collapse-icon"
+                                    :class="{ 'tier-section-collapse-icon--collapsed': isTierCollapsed(group) }">▾</span>
+                                <span class="tier-section-name">{{ tierGroupLabel(group) }}</span>
+                                <span class="tier-section-count">{{ (picklistStore.activeSections[group] || []).length }}</span>
+                            </div>
 
-                        <!-- Editable: draggable within and across tier sections -->
-                        <draggable v-if="isEditable" v-show="!isTierCollapsed(group)" :list="picklistStore.activeSections[group]"
-                            group="picklist" :item-key="(el) => el" handle=".picklist-drag-handle" animation="200"
-                            ghost-class="picklist-row--ghost" :force-fallback="true" :scroll="false"
-                            class="tier-section-body" @start="onDragStart" @end="onDragEnd" @change="saveList">
-                            <template #item="{ element: teamNumber, index }">
-                                <PicklistRow :row-id="`picklist-team-${teamNumber}`" :team="picklistStore.teamMap[teamNumber]"
-                                    :position="groupRankOffset(group) + index + 1" :show-drag-handle="true" :show-vote-stats="showVoteStats"
+                            <!-- Editable: draggable within and across tier sections -->
+                            <draggable v-if="isEditable" v-show="!isTierCollapsed(group)" :list="picklistStore.activeSections[group]"
+                                group="picklist" :item-key="(el) => el" handle=".picklist-drag-handle" animation="200"
+                                ghost-class="picklist-row--ghost" :force-fallback="true" :scroll="false"
+                                class="tier-section-body" @start="onDragStart" @end="onDragEnd" @change="saveList">
+                                <template #item="{ element: teamNumber, index }">
+                                    <PicklistRow :row-id="`picklist-team-${teamNumber}`" :team="picklistStore.teamMap[teamNumber]"
+                                        :position="groupRankOffset(group) + index + 1" :show-drag-handle="true" :show-vote-stats="showVoteStats"
+                                        :tier-stats="tierStatsFor(teamNumber)" :show-picked="showPickedCheckbox"
+                                        :is-picked="picklistStore.isTeamPicked(teamNumber)"
+                                        :can-toggle-picked="isLead" :card-status="picklistStore.cardStatusFor(teamNumber)"
+                                        :watched="watchlistStore.isWatched(teamNumber)"
+                                        :can-toggle-watch="isLead" :expanded="expandedTeam === teamNumber"
+                                        :expanded-data="expandedData" :expanded-loading="expandedLoading"
+                                        @toggle-expand="toggleExpand(teamNumber)" @toggle-picked="togglePicked(teamNumber)"
+                                        @toggle-watch="toggleWatch(teamNumber)" />
+                                </template>
+                            </draggable>
+
+                            <!-- Read-only (democratic tab) -->
+                            <div v-else v-show="!isTierCollapsed(group)" class="tier-section-body tier-section-body--static">
+                                <PicklistRow v-for="(teamNumber, index) in picklistStore.activeSections[group]" :key="teamNumber"
+                                    :row-id="`picklist-team-demo-${teamNumber}`" :team="picklistStore.teamMap[teamNumber]"
+                                    :position="groupRankOffset(group) + index + 1" :show-drag-handle="false" :show-vote-stats="showVoteStats"
                                     :tier-stats="tierStatsFor(teamNumber)" :show-picked="showPickedCheckbox"
                                     :is-picked="picklistStore.isTeamPicked(teamNumber)"
                                     :can-toggle-picked="isLead" :card-status="picklistStore.cardStatusFor(teamNumber)"
@@ -411,27 +431,57 @@ function toggleTierCollapse(group: string) {
                                     :expanded-data="expandedData" :expanded-loading="expandedLoading"
                                     @toggle-expand="toggleExpand(teamNumber)" @toggle-picked="togglePicked(teamNumber)"
                                     @toggle-watch="toggleWatch(teamNumber)" />
+                            </div>
+
+                            <div v-if="!isTierCollapsed(group) && (picklistStore.activeSections[group] || []).length === 0"
+                                class="tier-section-empty">
+                                {{ isEditable ? 'Drag teams here' : 'No teams in this tier' }}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="tier-section tier-section-unranked">
+                        <div class="tier-section-header tier-section-header--Unranked" @click="toggleTierCollapse('Unranked')">
+                            <span class="tier-section-collapse-icon"
+                                :class="{ 'tier-section-collapse-icon--collapsed': isTierCollapsed('Unranked') }">▾</span>
+                            <span class="tier-section-name">Unranked</span>
+                            <span class="tier-section-count">{{ (picklistStore.activeSections['Unranked'] || []).length }}</span>
+                        </div>
+
+                        <!-- Editable: same cross-tier drag group as the ranked
+                             lists above, so a team can be dragged either way
+                             between here and a ranked tier. Uses a real
+                             `handle`, same as every ranked tier's draggable —
+                             see PicklistUnrankedCard.vue for why relying on
+                             whole-card-drag + a `filter` exclusion instead
+                             broke both the move itself and every other list's
+                             dragging afterward. -->
+                        <draggable v-if="isEditable" v-show="!isTierCollapsed('Unranked')" :list="picklistStore.activeSections['Unranked']"
+                            group="picklist" :item-key="(el) => el" handle=".unranked-card-handle" animation="200"
+                            ghost-class="unranked-card--ghost" :force-fallback="true" :scroll="false"
+                            class="unranked-grid" @start="onDragStart" @end="onDragEnd" @change="saveList">
+                            <template #item="{ element: teamNumber }">
+                                <PicklistUnrankedCard :row-id="`picklist-unranked-${teamNumber}`" :team="picklistStore.teamMap[teamNumber]"
+                                    :watched="watchlistStore.isWatched(teamNumber)" :can-toggle-watch="isLead"
+                                    :expanded="expandedTeam === teamNumber" :expanded-data="expandedData"
+                                    :expanded-loading="expandedLoading" @toggle-expand="toggleExpand(teamNumber)"
+                                    @toggle-watch="toggleWatch(teamNumber)" />
                             </template>
                         </draggable>
 
                         <!-- Read-only (democratic tab) -->
-                        <div v-else v-show="!isTierCollapsed(group)" class="tier-section-body tier-section-body--static">
-                            <PicklistRow v-for="(teamNumber, index) in picklistStore.activeSections[group]" :key="teamNumber"
-                                :row-id="`picklist-team-demo-${teamNumber}`" :team="picklistStore.teamMap[teamNumber]"
-                                :position="groupRankOffset(group) + index + 1" :show-drag-handle="false" :show-vote-stats="showVoteStats"
-                                :tier-stats="tierStatsFor(teamNumber)" :show-picked="showPickedCheckbox"
-                                :is-picked="picklistStore.isTeamPicked(teamNumber)"
-                                :can-toggle-picked="isLead" :card-status="picklistStore.cardStatusFor(teamNumber)"
-                                :watched="watchlistStore.isWatched(teamNumber)"
-                                :can-toggle-watch="isLead" :expanded="expandedTeam === teamNumber"
-                                :expanded-data="expandedData" :expanded-loading="expandedLoading"
-                                @toggle-expand="toggleExpand(teamNumber)" @toggle-picked="togglePicked(teamNumber)"
+                        <div v-else v-show="!isTierCollapsed('Unranked')" class="unranked-grid">
+                            <PicklistUnrankedCard v-for="teamNumber in picklistStore.activeSections['Unranked']" :key="teamNumber"
+                                :row-id="`picklist-unranked-demo-${teamNumber}`" :team="picklistStore.teamMap[teamNumber]"
+                                :watched="watchlistStore.isWatched(teamNumber)" :can-toggle-watch="isLead"
+                                :expanded="expandedTeam === teamNumber" :expanded-data="expandedData"
+                                :expanded-loading="expandedLoading" @toggle-expand="toggleExpand(teamNumber)"
                                 @toggle-watch="toggleWatch(teamNumber)" />
                         </div>
 
-                        <div v-if="!isTierCollapsed(group) && (picklistStore.activeSections[group] || []).length === 0"
+                        <div v-if="!isTierCollapsed('Unranked') && (picklistStore.activeSections['Unranked'] || []).length === 0"
                             class="tier-section-empty">
-                            {{ isEditable ? 'Drag teams here' : 'No teams in this tier' }}
+                            {{ isEditable ? 'Drag teams here' : 'No unranked teams' }}
                         </div>
                     </div>
                 </div>
@@ -444,6 +494,12 @@ function toggleTierCollapse(group: string) {
 .picklist-page {
     max-width: 860px;
     margin: 0 auto;
+}
+
+@media (min-width: 1000px) {
+    .picklist-page {
+        max-width: 1180px;
+    }
 }
 
 /* ── Header ── */
@@ -608,10 +664,62 @@ function toggleTierCollapse(group: string) {
 }
 
 /* ── Tier sections ── */
-.tier-sections {
+/* Ranked tiers stack on the left, Unranked pool on the right — on desktop
+   only (issue #34); both columns stack vertically on narrower viewports,
+   Unranked last. */
+.picklist-columns {
     display: flex;
     flex-direction: column;
     gap: 18px;
+}
+
+.tier-sections-ranked {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    min-width: 0;
+}
+
+@media (min-width: 1000px) {
+    .picklist-columns {
+        flex-direction: row;
+        align-items: flex-start;
+    }
+
+    .tier-sections-ranked {
+        flex: 1;
+    }
+
+    .tier-section-unranked {
+        width: 360px;
+        flex-shrink: 0;
+    }
+}
+
+/* flex-wrap, not CSS grid: SortableJS's index/swap math is unreliable
+   inside a `display: grid` container (well-documented upstream issue —
+   its direction-detection heuristics assume flex/block flow), which is
+   what made drag-and-drop into/out of this section fail in practice. Each
+   card gets a fixed one-third width instead, giving exactly 3 per row. */
+.unranked-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    min-height: 50px;
+}
+
+.unranked-grid > .unranked-card {
+    flex: 0 0 calc((100% - 20px) / 3);
+    max-width: calc((100% - 20px) / 3);
+}
+
+/* An expanded card takes the full row (~3 columns) instead of 1/3 — needs
+   equal-specificity + later source order to beat the rule above, since
+   PicklistUnrankedCard.vue's own `.unranked-card--expanded` sizing (lower
+   specificity than this parent-scoped selector) can't override it alone. */
+.unranked-grid > .unranked-card--expanded {
+    flex: 1 1 100%;
+    max-width: 100%;
 }
 
 .tier-section {

--- a/src/views/StrategyView.vue
+++ b/src/views/StrategyView.vue
@@ -621,7 +621,7 @@ export default {
     gap: 10px;
 }
 
-@media (max-width: 820px) {
+@media (max-width: 1000px) {
     .autopath-side-by-side {
         flex-direction: column;
         gap: 24px;


### PR DESCRIPTION
Two-column desktop layout (ranked tiers left, Unranked grid right, 1000px breakpoint), 3-per-row unranked cards with click-to-expand for full stats/comments, nav bar auto-hides on scroll down, and Auto Fail % added to the shared expanded stats view.

Fixes a real vuedraggable bug where a template-level HTML comment before PicklistUnrankedCard's root div compiled to a fragment root, so vuedraggable never attached drag context to any unranked card -- starting any drag threw and corrupted drag state for every list on the page. Also fixes photo cropping (object-fit: contain) and drops the meaningless "Id" stat from the expanded view.


Closes #34 