### PR TITLE
Make dropdowns searchable app-wide and improve the strategy whiteboard

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -353,4 +353,34 @@ div.tile-item {
 /* Picklist page max-width wrapper */
 .picklist-page {
   max-width: 860px;
+}
+
+/* On mobile, the tile classes' full-size margin/padding above eats a large
+   share of an already-narrow screen — shrink both here so tiles fill
+   nearly the full width, keeping just enough margin/padding to still read
+   as a distinct tile rather than the page background. */
+@media (max-width: 700px) {
+  div.main-content {
+    padding: 0.75rem;
+  }
+
+  .tile-container,
+  .login-tile,
+  .user-tile,
+  .data-tile,
+  .graph-tile,
+  .comment-tile,
+  .image-tile,
+  .file-upload-tile {
+    margin: 6px;
+    padding: 12px;
+  }
+
+  .scout-form-tile {
+    padding: 12px 5px;
+  }
+
+  div.tile-item {
+    margin: 6px;
+  }
 }

--- a/src/components/AutoPathCanvas.vue
+++ b/src/components/AutoPathCanvas.vue
@@ -78,6 +78,17 @@ import fieldImage from "@/assets/2026-field.png";
                 </rect>
                 <text :x="VIEW_W / 2" :y="VIEW_H / 2" class="empty-hint">Draw the auto path here</text>
             </g>
+
+            <!-- Big team-number/name labels next to the field art's printed
+                 R1/R2/R3 and B1/B2/B3 driver-station markings, so it's
+                 obvious at a glance which team is standing where. Only shown
+                 when the caller (Strategy Preview) hands us assignments.
+                 Drawn last (on top of paths/markers) since a path's start
+                 point sits right where these labels do. -->
+            <template v-for="label in stationLabelViews" :key="`station-${label.slot}`">
+                <text :x="label.cx" :y="label.cy" :text-anchor="label.anchor" class="station-label"
+                    :style="{ fill: label.color }">{{ label.text }}</text>
+            </template>
         </svg>
     </div>
 </template>
@@ -102,6 +113,34 @@ const FIELD_BOUNDS = { left: 0.13113, right: 0.86874, top: 0.05278, bottom: 0.94
 // VIEW_W/VIEW_H. 0.8x of the original 3x-enlarged size (48) per issue #32
 // follow-up feedback.
 const MARKER_PHOTO_SIZE = 38;
+
+// Vertical position (fraction of the FULL field image, top to bottom) of
+// the field art's printed "1"/"2"/"3" driver-station row for a red-side
+// slot, measured directly from src/assets/2026-field.png. Blue's rows sit
+// at the point-symmetric mirror of these (1 - y) — same 180-degree
+// point-symmetry the rest of this file already relies on (see toView) —
+// which is also why Red N and Blue N end up diagonally opposite each
+// other rather than side-by-side.
+const STATION_ROW_Y = [0.1628, 0.3637, 0.6966];
+
+// Where each of the 6 alliance slots' driver-station label anchors, in FULL
+// image fraction coordinates (not the FIELD_BOUNDS sub-rectangle path
+// points use) — these sit just OUTSIDE the playing field's own edge (red to
+// its left, blue to its right), in the margin where the field art's
+// driver-station markings already are, never over the playing surface.
+function stationPosition(slot) {
+    const isRed = slot < 3;
+    const row = slot % 3;
+    return {
+        x: isRed ? FIELD_BOUNDS.left : FIELD_BOUNDS.right,
+        y: isRed ? STATION_ROW_Y[row] : 1 - STATION_ROW_Y[row],
+        // Anchored away from the field: red text ends at the field edge and
+        // grows further left (into the margin); blue starts at the field
+        // edge and grows further right — so neither ever renders over the
+        // field itself.
+        anchor: isRed ? 'end' : 'start'
+    };
+}
 
 // Position along a polyline of already-view-space {cx, cy} points at time
 // fraction `t` (0..1), using each point's own recorded time rather than
@@ -230,6 +269,14 @@ export default {
         robotPhotoUrl: {
             type: String,
             default: null
+        },
+        // Optional [{ slot: 0-5, text, color }] — big team labels drawn next
+        // to the field art's printed driver-station markings. slot follows
+        // the same 0-2 red / 3-5 blue convention as everywhere else (see
+        // STATION_POSITIONS below for the physical position each maps to).
+        stationLabels: {
+            type: Array,
+            default: () => []
         }
     },
     emits: ["update:points", "finished", "progress"],
@@ -261,6 +308,20 @@ export default {
     computed: {
         hasLayers() {
             return this.layers.length > 0;
+        },
+        stationLabelViews() {
+            const PADDING = 8;
+            return this.stationLabels.map((label) => {
+                const pos = stationPosition(label.slot);
+                return {
+                    slot: label.slot,
+                    text: label.text,
+                    color: label.color,
+                    anchor: pos.anchor,
+                    cx: pos.x * VIEW_W + (pos.anchor === 'start' ? PADDING : -PADDING),
+                    cy: pos.y * VIEW_H
+                };
+            });
         },
         displayPoints() {
             return this.points ?? [];
@@ -518,6 +579,12 @@ export default {
 .path-end {
     stroke: none;
     opacity: 0.6;
+}
+
+.station-label {
+    font-size: 18px;
+    font-weight: 700;
+    dominant-baseline: middle;
 }
 
 .path-label {

--- a/src/components/ColorSwatchPicker.vue
+++ b/src/components/ColorSwatchPicker.vue
@@ -4,15 +4,24 @@
 
 <template>
     <div class="color-swatch-picker">
-        <button v-for="(choice, idx) in choices" :key="choice.key" type="button" class="color-swatch-option"
-            :class="{ 'color-swatch-option--active': idx === modelValue }" :style="{ backgroundColor: choice.hex }"
-            :aria-label="choice.text" :title="choice.text" @click="$emit('update:modelValue', idx)"></button>
+        <button type="button" class="color-swatch-current" :class="{ 'color-swatch--white': activeChoice.key === 'white' }"
+            :style="{ backgroundColor: activeChoice.hex }" :aria-label="`Team color: ${activeChoice.text}. Click to change.`"
+            title="Click to choose a different color" @click="isOpen = !isOpen" @blur="onBlur"
+            @keydown.esc="isOpen = false"></button>
+        <div v-if="isOpen" class="color-swatch-palette">
+            <button v-for="(choice, idx) in choices" :key="choice.key" type="button" class="color-swatch-option"
+                :class="{ 'color-swatch-option--active': idx === modelValue, 'color-swatch--white': choice.key === 'white' }"
+                :style="{ backgroundColor: choice.hex }" :aria-label="choice.text" :title="choice.text"
+                @mousedown.prevent="selectChoice(idx)"></button>
+        </div>
     </div>
 </template>
 
 <script lang="ts">
-// Click-to-pick row of color blocks (issue #32 feedback: a team's color
-// should be a visual swatch picker, not a text dropdown).
+// Click-to-expand palette (issue #45 follow-up): the current color shows as
+// a single swatch button; clicking it reveals the full palette instead of
+// always showing every color in a row (issue #32's original design), which
+// got crowded once this control was reused per alliance slot.
 export default {
     props: {
         choices: {
@@ -24,15 +33,62 @@ export default {
             required: true
         }
     },
-    emits: ["update:modelValue"]
+    emits: ["update:modelValue"],
+    data() {
+        return {
+            isOpen: false
+        };
+    },
+    computed: {
+        activeChoice() {
+            return this.choices[this.modelValue] ?? this.choices[0];
+        }
+    },
+    methods: {
+        onBlur() {
+            // Delayed so a click on a palette option (mousedown, which fires
+            // before blur) still registers before the palette closes.
+            setTimeout(() => { this.isOpen = false; }, 150);
+        },
+        selectChoice(idx) {
+            this.$emit('update:modelValue', idx);
+            this.isOpen = false;
+        }
+    }
 };
 </script>
 
 <style scoped>
 .color-swatch-picker {
+    position: relative;
+    display: inline-flex;
+}
+
+.color-swatch-current {
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    border: 2px solid var(--primary-text-color, #fff);
+    padding: 0;
+    cursor: pointer;
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.45);
+}
+
+.color-swatch-palette {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 20;
     display: flex;
-    gap: 6px;
     flex-wrap: wrap;
+    gap: 6px;
+    width: 132px;
+    margin-top: 6px;
+    padding: 8px;
+    background: var(--tile-background-color);
+    border: 1px solid rgba(128, 128, 128, 0.35);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
 }
 
 .color-swatch-option {
@@ -47,5 +103,13 @@ export default {
 .color-swatch-option--active {
     border-color: var(--primary-text-color, #fff);
     box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.45);
+}
+
+/* The 'white' choice is a near-invisible swatch against light mode's white
+   tile background — shown as black there instead so it's still pickable.
+   The choice's real hex (used for actual strokes/labels drawn in that
+   color) is untouched; this only affects how the swatch button looks. */
+[theme="light"] .color-swatch--white {
+    background-color: #000 !important;
 }
 </style>

--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -1,46 +1,171 @@
 <script setup lang="ts">
 // TODO: fix types
 // @ts-nocheck
-
-import '@material/web/select/outlined-select';
 </script>
 
 <template>
-    <md-outlined-select class="choice-select" :key="modelValue" v-bind:display-text="getActiveChoice.text"
-        :error="error">
-        <md-select-option v-for="choice, idx in choices" v-bind:selected="idx == modelValue" :key="choice.key"
-            :ref="getActiveChoice.key" v-bind:aria-label="choice.text" @click="setChoice(idx)">
-            <div slot="headline">{{ choice.text }}</div>
-        </md-select-option>
-    </md-outlined-select>
+    <div class="dropdown-select" :class="{ 'dropdown-select--error': error }">
+        <input type="text" class="dropdown-select-input" :style="{ minWidth: minWidthCh }" :placeholder="placeholder"
+            :value="displayValue" :required="required" @input="onInput" @focus="onFocus" @blur="onBlur"
+            @keydown="onKeydown" />
+        <ul v-if="isOpen" class="dropdown-select-list">
+            <li v-if="filteredChoices.length === 0" class="dropdown-select-empty">No matches</li>
+            <li v-for="entry in filteredChoices" :key="entry.idx" class="dropdown-select-option"
+                :class="{ 'dropdown-select-option--active': entry.idx === modelValue }"
+                @mousedown.prevent="selectChoice(entry.idx)">
+                {{ entry.text }}
+            </li>
+        </ul>
+    </div>
 </template>
 
 <script lang="ts">
 export default {
     props: {
-        choices: {
-            default: []
+        choices: { default: () => [] },
+        // Index into choices — kept index-based (rather than SearchableDropdown's
+        // key-based binding) since callers throughout the app, including
+        // parseScoutData() for scouting-form submissions, already treat this
+        // modelValue as a position in the choices array.
+        modelValue: { required: true },
+        error: { default: false },
+        required: { default: false },
+        placeholder: { default: 'Search…' }
+    },
+    emits: ['update:modelValue'],
+    data() {
+        return {
+            // null = not actively editing; the input shows the current
+            // selection's text. Once the user types, this holds their
+            // literal query until blur/select/Escape resets it to null.
+            query: null,
+            isOpen: false
+        };
+    },
+    computed: {
+        activeChoice() {
+            // Out-of-bounds modelValue falls back to an empty choice so callers
+            // can't crash the input while a valid selection is pending.
+            return this.choices[this.modelValue] ?? null;
         },
-        modelValue: {
-            required: true
+        displayValue() {
+            return this.query !== null ? this.query : (this.activeChoice?.text ?? '');
         },
-        error: {
-            default: false
+        filteredChoices() {
+            const indexed = this.choices.map((choice, idx) => ({ ...choice, idx }));
+            const q = (this.query ?? '').trim().toLowerCase();
+            if (!q) return indexed;
+            return indexed.filter((c) => c.text.toLowerCase().includes(q));
+        },
+        // Sized to the widest possible choice (not just the current value) so
+        // the box never visually clips a selection's text — a plain <input>
+        // otherwise defaults to a fixed browser width regardless of its
+        // value's length — and so it doesn't reflow narrower/wider as the
+        // user picks between differently-sized choices.
+        minWidthCh() {
+            const longest = this.choices.reduce((max, c) => Math.max(max, (c.text ?? '').length), this.placeholder.length);
+            return `${Math.max(longest + 2, 10)}ch`;
         }
     },
     methods: {
-        setChoice(idx: int) {
-            this.$emit("update:modelValue", idx);
-        }
-    },
-    computed: {
-        getActiveChoice() {
-            // If the active choice index is out of bounds, return an empty object just to prevent the caller from crashing.
-            if (this.modelValue >= this.choices.length) {
-                return {};
-            }
-            return this.choices[this.modelValue];
+        onInput(event) {
+            this.query = event.target.value;
+            this.isOpen = true;
         },
+        onFocus() {
+            this.query = '';
+            this.isOpen = true;
+        },
+        onBlur() {
+            // Delayed so a click on an option (mousedown, which fires before
+            // blur) still registers before the list closes.
+            setTimeout(() => {
+                this.query = null;
+                this.isOpen = false;
+            }, 150);
+        },
+        onKeydown(event) {
+            if (event.key === 'Escape') {
+                this.query = null;
+                this.isOpen = false;
+                event.target.blur();
+            } else if (event.key === 'Enter') {
+                event.preventDefault();
+                const first = this.filteredChoices[0];
+                if (first) this.selectChoice(first.idx);
+            }
+        },
+        selectChoice(idx) {
+            this.$emit('update:modelValue', idx);
+            this.query = null;
+            this.isOpen = false;
+        }
     }
 }
 </script>
+
+<style scoped>
+.dropdown-select {
+    position: relative;
+}
+
+.dropdown-select-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 10px 12px;
+    font-size: 1rem;
+    font-family: inherit;
+    border-radius: 6px;
+    border: 1px solid rgba(128, 128, 128, 0.35);
+    background-color: transparent;
+    color: var(--primary-text-color);
+}
+
+.dropdown-select-input:hover {
+    border-color: rgba(128, 128, 128, 0.6);
+}
+
+.dropdown-select-input:focus {
+    outline: none;
+    border-color: #b05703;
+}
+
+.dropdown-select--error .dropdown-select-input {
+    border-color: #c0392b;
+}
+
+.dropdown-select-list {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 20;
+    max-height: 260px;
+    overflow-y: auto;
+    margin: 4px 0 0;
+    padding: 4px 0;
+    list-style: none;
+    background: var(--tile-background-color);
+    color: var(--primary-text-color);
+    border: 1px solid rgba(128, 128, 128, 0.35);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+.dropdown-select-option {
+    padding: 8px 14px;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.dropdown-select-option:hover,
+.dropdown-select-option--active {
+    background: rgba(176, 87, 3, 0.15);
+}
+
+.dropdown-select-empty {
+    padding: 8px 14px;
+    color: rgba(128, 128, 128, 0.7);
+    font-size: 14px;
+}
+</style>

--- a/src/components/SearchableDropdown.vue
+++ b/src/components/SearchableDropdown.vue
@@ -5,8 +5,8 @@
 
 <template>
     <div class="searchable-dropdown">
-        <input type="text" class="searchable-dropdown-input" :placeholder="placeholder" :value="displayValue"
-            @input="onInput" @focus="onFocus" @blur="onBlur" @keydown="onKeydown" />
+        <input type="text" class="searchable-dropdown-input" :style="{ minWidth: minWidthCh }" :placeholder="placeholder"
+            :value="displayValue" @input="onInput" @focus="onFocus" @blur="onBlur" @keydown="onKeydown" />
         <ul v-if="isOpen" class="searchable-dropdown-list">
             <li v-if="filteredChoices.length === 0" class="searchable-dropdown-empty">No matches</li>
             <li v-for="choice in filteredChoices" :key="choice.key" class="searchable-dropdown-option"
@@ -49,6 +49,15 @@ export default {
             const q = (this.query ?? '').trim().toLowerCase();
             if (!q) return this.choices;
             return this.choices.filter((c) => c.text.toLowerCase().includes(q));
+        },
+        // Sized to the widest possible choice (not just the current value) so
+        // the box never visually clips a selection's text — a plain <input>
+        // otherwise defaults to a fixed browser width regardless of its
+        // value's length — and so it doesn't reflow narrower/wider as the
+        // user picks between differently-sized choices.
+        minWidthCh() {
+            const longest = this.choices.reduce((max, c) => Math.max(max, (c.text ?? '').length), this.placeholder.length);
+            return `${Math.max(longest + 2, 10)}ch`;
         }
     },
     methods: {

--- a/src/components/StrategyBoard.vue
+++ b/src/components/StrategyBoard.vue
@@ -25,17 +25,32 @@ import "@material/web/button/filled-button";
                     Drawing For:
                     <Dropdown :choices="slotChoices" v-model="activeSlot"></Dropdown>
                 </div>
-                <md-filled-button v-on:click="clearActiveSlot" class="reset-button">
-                    CLEAR {{ activeTeamLabel }}'S STROKES
-                </md-filled-button>
             </div>
-            <StrategyCanvas :board="board" :active-slot="activeSlot" :slot-color="slotColor"
-                @update:board="onBoardUpdate"></StrategyCanvas>
+            <div class="whiteboard-toolbar">
+                <div class="tool-toggle">
+                    <md-filled-button type="button" v-on:click="tool = 'draw'"
+                        :class="{ 'mode-inactive': tool !== 'draw' }">Draw</md-filled-button>
+                    <md-filled-button type="button" v-on:click="tool = 'erase'"
+                        :class="{ 'mode-inactive': tool !== 'erase' }">Erase</md-filled-button>
+                </div>
+                <md-filled-button type="button" v-on:click="undo" :disabled="undoStack.length === 0"
+                    class="reset-button">Undo</md-filled-button>
+                <md-filled-button type="button" v-on:click="clearActiveSlot" :disabled="!activeSlotHasStrokes"
+                    class="reset-button">
+                    Clear {{ activeTeamLabel }}'s Strokes
+                </md-filled-button>
+                <md-filled-button type="button" v-on:click="clearAllStrokes" :disabled="board.length === 0"
+                    class="reset-button">Clear All Strokes</md-filled-button>
+            </div>
+            <StrategyCanvas :board="board" :active-slot="activeSlot" :slot-color="slotColor" :tool="tool"
+                @update:board="onBoardUpdate" @stroke-start="pushHistory"></StrategyCanvas>
         </template>
     </div>
 </template>
 
 <script lang="ts">
+const MAX_UNDO_STEPS = 50;
+
 export default {
     props: {
         matchNumber: {
@@ -62,6 +77,13 @@ export default {
             boardId: null,
             board: [],
             activeSlot: 0,
+            // 'draw' or 'erase' — passed straight through to StrategyCanvas.
+            tool: 'draw',
+            // Snapshots of `board` taken right before each destructive action
+            // (a new stroke/erase drag, or a clear), so Undo can pop back to
+            // them. Capped so a long whiteboard session can't grow this
+            // unbounded.
+            undoStack: [],
             saveStatus: '',
             saveTimer: null,
             statusTimer: null
@@ -77,6 +99,9 @@ export default {
         },
         activeTeamLabel() {
             return this.teamFilters.find((t) => t.key === this.teamNumbers[this.activeSlot])?.text ?? 'Team';
+        },
+        activeSlotHasStrokes() {
+            return this.board.some((entry) => entry.slot === this.activeSlot && entry.strokes.length > 0);
         }
     },
     watch: {
@@ -86,6 +111,10 @@ export default {
     },
     methods: {
         async loadBoard() {
+            // A freshly loaded board is a new editing session — old undo
+            // steps would refer to a different match's strokes.
+            this.undoStack = [];
+
             if (!this.matchNumber) {
                 this.board = [];
                 this.boardId = null;
@@ -100,8 +129,26 @@ export default {
             this.board = newBoard;
             this.scheduleSave();
         },
+        // Snapshots the current board onto the undo stack — called right
+        // before any destructive change (a new draw/erase drag, or a clear)
+        // so that change can be undone as one step.
+        pushHistory() {
+            this.undoStack.push(JSON.parse(JSON.stringify(this.board)));
+            if (this.undoStack.length > MAX_UNDO_STEPS) this.undoStack.shift();
+        },
+        undo() {
+            if (this.undoStack.length === 0) return;
+            this.board = this.undoStack.pop();
+            this.scheduleSave();
+        },
         clearActiveSlot() {
+            this.pushHistory();
             this.board = this.board.filter((entry) => entry.slot !== this.activeSlot);
+            this.scheduleSave();
+        },
+        clearAllStrokes() {
+            this.pushHistory();
+            this.board = [];
             this.scheduleSave();
         },
         scheduleSave() {

--- a/src/components/StrategyCanvas.vue
+++ b/src/components/StrategyCanvas.vue
@@ -6,8 +6,9 @@ import fieldImage from "@/assets/2026-field.png";
 <template>
     <div class="strategy-canvas">
         <svg :viewBox="`0 0 ${VIEW_W} ${VIEW_H}`" preserveAspectRatio="xMidYMid meet" ref="svg"
-            @pointerdown="onPointerDown" @pointermove="onPointerMove" @pointerup="onPointerUp"
-            @pointercancel="onPointerUp" @pointerleave="onPointerUp">
+            :class="{ 'strategy-canvas-svg--erase': tool === 'erase' }" @pointerdown="onPointerDown"
+            @pointermove="onPointerMove" @pointerup="onPointerUp" @pointercancel="onPointerUp"
+            @pointerleave="onPointerUp">
             <!-- Strategy board coordinates are always drawn directly onto this
                  real fixed-orientation field (red-left, blue-right) — unlike
                  AutoPath, there's no per-team own-relative reframing to undo,
@@ -35,6 +36,10 @@ import fieldImage from "@/assets/2026-field.png";
 const VIEW_W = 740;
 const VIEW_H = 300;
 const FIELD_BOUNDS = { left: 0.13113, right: 0.86874, top: 0.05278, bottom: 0.94691 };
+// Hit-test radius for the eraser tool, in the same view-space units as
+// VIEW_W/VIEW_H — generous enough to catch a stroke without requiring
+// pixel-perfect aim on a touch device.
+const ERASE_RADIUS = 12;
 
 export default {
     props: {
@@ -51,9 +56,16 @@ export default {
         slotColor: {
             type: Function,
             required: true
+        },
+        // 'draw' appends to the active slot's strokes as before; 'erase'
+        // instead removes whichever whole strokes (from any slot) the
+        // pointer passes over.
+        tool: {
+            type: String,
+            default: 'draw'
         }
     },
-    emits: ["update:board"],
+    emits: ["update:board", "stroke-start"],
     data() {
         return {
             VIEW_W,
@@ -107,16 +119,55 @@ export default {
 
             this.$emit("update:board", board);
         },
+        // Removes every whole stroke (from any slot, not just activeSlot —
+        // the eraser is a shared whiteboard tool for tidying up the board,
+        // not a per-team action) that passes within ERASE_RADIUS of
+        // rawPoint. Whole-stroke removal rather than partial/pixel erasing
+        // keeps the hit-testing simple: a stroke is either touched or not.
+        eraseAt(rawPoint) {
+            const target = this.toView(rawPoint);
+            let changed = false;
+
+            const board = this.board
+                .map((entry) => ({
+                    ...entry,
+                    strokes: entry.strokes.filter((stroke) => {
+                        const hit = stroke.some((p) => {
+                            const v = this.toView(p);
+                            const dx = v.cx - target.cx;
+                            const dy = v.cy - target.cy;
+                            return dx * dx + dy * dy <= ERASE_RADIUS * ERASE_RADIUS;
+                        });
+                        if (hit) changed = true;
+                        return !hit;
+                    })
+                }))
+                .filter((entry) => entry.strokes.length > 0);
+
+            if (changed) this.$emit("update:board", board);
+        },
         onPointerDown(event) {
             event.preventDefault();
             this.isDrawing = true;
             this.$refs.svg.setPointerCapture?.(event.pointerId);
-            this.pushPoint(this.fromEvent(event), true);
+            // Emitted before the first mutation of this drag so the parent
+            // can snapshot the board for undo — one snapshot per drag,
+            // whether it ends up drawing one stroke or erasing several.
+            this.$emit("stroke-start");
+            if (this.tool === 'erase') {
+                this.eraseAt(this.fromEvent(event));
+            } else {
+                this.pushPoint(this.fromEvent(event), true);
+            }
         },
         onPointerMove(event) {
             if (!this.isDrawing) return;
             event.preventDefault();
-            this.pushPoint(this.fromEvent(event), false);
+            if (this.tool === 'erase') {
+                this.eraseAt(this.fromEvent(event));
+            } else {
+                this.pushPoint(this.fromEvent(event), false);
+            }
         },
         onPointerUp() {
             this.isDrawing = false;
@@ -139,6 +190,10 @@ export default {
     -webkit-user-select: none;
     user-select: none;
     cursor: crosshair;
+}
+
+.strategy-canvas svg.strategy-canvas-svg--erase {
+    cursor: cell;
 }
 
 .board-stroke {

--- a/src/views/AccountView.vue
+++ b/src/views/AccountView.vue
@@ -4,6 +4,7 @@
 
 import "@material/web/button/filled-button";
 import TextInput from '@/components/TextInput.vue';
+import SearchableDropdown from '@/components/SearchableDropdown.vue';
 
 import { supabase } from "@/lib/supabase-client";
 
@@ -36,12 +37,11 @@ import { fetchAllUsers, updateUserRole } from "@/lib/user-query";
                         <td>{{ person.name || 'Unnamed user' }}</td>
                         <td class="people-role">{{ person.role }}</td>
                         <td>
-                            <select v-if="person.user_id !== authStore.currentUserId && allowedRoles(person.role).length > 0"
-                                class="role-select" :value="pendingRole[person.user_id] || ''"
-                                @change="changeRole(person, $event.target.value)">
-                                <option disabled value="">Change role…</option>
-                                <option v-for="r in allowedRoles(person.role)" :key="r" :value="r">{{ r }}</option>
-                            </select>
+                            <SearchableDropdown
+                                v-if="person.user_id !== authStore.currentUserId && allowedRoles(person.role).length > 0"
+                                class="role-select" :choices="roleChoices(person.role)"
+                                :model-value="pendingRole[person.user_id] || ''" placeholder="Change role…"
+                                @update:modelValue="changeRole(person, $event)"></SearchableDropdown>
                         </td>
                     </tr>
                 </tbody>
@@ -74,6 +74,9 @@ export default {
             this.peopleLoaded = false;
             this.people = await fetchAllUsers();
             this.peopleLoaded = true;
+        },
+        roleChoices(targetRole) {
+            return this.allowedRoles(targetRole).map((r) => ({ key: r, text: r }));
         },
         allowedRoles(targetRole) {
             const actorRank = roleRank[this.authStore.role] ?? -1;
@@ -155,21 +158,6 @@ export default {
 
 .role-select {
     display: block;
-    padding: 10px 8px;
-    font-size: 1rem;
-    border-radius: 6px;
-    border: 1px solid rgba(128, 128, 128, 0.35);
-    background-color: transparent;
-    color: var(--primary-text-color);
-    cursor: pointer;
-}
-
-.role-select:hover {
-    border-color: rgba(128, 128, 128, 0.6);
-}
-
-.role-select option {
-    color: initial;
-    background-color: initial;
+    min-width: 160px;
 }
 </style>

--- a/src/views/PickEmView.vue
+++ b/src/views/PickEmView.vue
@@ -331,31 +331,51 @@ const infoModalTeamNumber = computed(() => infoModalSide.value === 'candidate' ?
                 </div>
 
                 <div class="pickem-modal-body">
-                    <div v-if="infoModalData?.stats.length > 0" class="pickem-stats-grid">
-                        <div v-for="stat in computeFlagStats(infoModalData.stats)" :key="stat.label"
-                            class="pickem-stat">
-                            <div class="stat-label">{{ stat.label }}</div>
-                            <div class="stat-avg">{{ stat.pct }}%</div>
-                        </div>
-                        <div v-for="stat in computeBasicStats(infoModalData.stats)" :key="stat.label"
-                            class="pickem-stat">
-                            <div class="stat-label">{{ stat.label }}</div>
-                            <div class="stat-avg">{{ stat.avg }}</div>
+                    <!-- Same expanded-detail data summary as the ranked Pick List rows
+                         (PicklistRow.vue) — full photo, per-match-count stat cards, and
+                         comments with their match number — so a team looks the same
+                         whether you're reviewing it here or on the Pick List. -->
+                    <div class="pickem-detail-photo" v-if="infoModalTeam?.photo_url">
+                        <img :src="infoModalTeam.photo_url" :alt="`Team ${infoModalTeamNumber} robot (full)`"
+                            class="pickem-full-photo" />
+                    </div>
+
+                    <div class="pickem-detail-section" v-if="infoModalData?.stats.length > 0">
+                        <h3 class="pickem-detail-heading">Match Stats ({{ infoModalData.stats.length }} matches)</h3>
+                        <div class="pickem-stats-grid">
+                            <div v-for="stat in computeFlagStats(infoModalData.stats)" :key="stat.label"
+                                class="pickem-stat">
+                                <div class="stat-label">{{ stat.label }}</div>
+                                <div class="stat-avg">{{ stat.pct }}%</div>
+                                <div class="stat-sub">{{ stat.count }} / {{ stat.total }} matches</div>
+                            </div>
+                            <div v-for="stat in computeBasicStats(infoModalData.stats)" :key="stat.label"
+                                class="pickem-stat">
+                                <div class="stat-label">{{ stat.label }}</div>
+                                <div class="stat-avg">{{ stat.avg }}</div>
+                                <div class="stat-sub">avg &nbsp;|&nbsp; max {{ stat.max }}</div>
+                            </div>
                         </div>
                     </div>
                     <p v-else class="pickem-no-data">No match data available.</p>
 
-                    <h3 class="pickem-modal-section-title">Comments</h3>
-                    <ul v-if="infoModalData?.comments.length > 0" class="pickem-comments">
-                        <li v-for="(comment, cIdx) in infoModalData.comments" :key="cIdx" class="pickem-comment">
-                            <div class="comment-meta">
-                                <span class="comment-author">{{ comment.author }}</span>
-                                <span class="comment-source-badge">{{ comment.source }}</span>
-                            </div>
-                            <p class="comment-text">{{ comment.comment }}</p>
-                        </li>
-                    </ul>
-                    <p v-else class="pickem-no-data">No comments yet.</p>
+                    <div class="pickem-detail-section" v-if="infoModalData?.comments.length > 0">
+                        <h3 class="pickem-detail-heading">Scout Comments</h3>
+                        <ul class="pickem-comments">
+                            <li v-for="(comment, cIdx) in infoModalData.comments" :key="cIdx" class="pickem-comment">
+                                <div class="comment-meta">
+                                    <span class="comment-author">{{ comment.author }}</span>
+                                    <span class="comment-source-badge">{{ comment.source }}</span>
+                                    <span class="comment-match" v-if="comment.match_number != null">Match
+                                        {{ comment.match_number }}</span>
+                                </div>
+                                <p class="comment-text">{{ comment.comment }}</p>
+                            </li>
+                        </ul>
+                    </div>
+                    <p v-else-if="infoModalData?.stats.length === 0" class="pickem-no-data">
+                        No scouting data available for this team.
+                    </p>
 
                     <PitScoutingSection :team-number="infoModalTeamNumber"></PitScoutingSection>
                 </div>
@@ -550,40 +570,67 @@ const infoModalTeamNumber = computed(() => infoModalSide.value === 'candidate' ?
     overflow-y: auto;
 }
 
-.pickem-modal-section-title {
+.pickem-detail-photo {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 18px;
+}
+
+.pickem-full-photo {
+    max-width: 340px;
+    width: 100%;
+    border-radius: 10px;
+    object-fit: cover;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+}
+
+.pickem-detail-section {
+    margin-bottom: 18px;
+}
+
+.pickem-detail-heading {
     font-size: 14px;
-    margin: 20px 0 8px;
+    font-weight: 700;
+    color: #b05703;
+    margin-bottom: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
 }
 
 .pickem-stats-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(85px, 1fr));
-    gap: 8px;
-    margin-bottom: 8px;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    gap: 10px;
 }
 
 .pickem-stat {
     background: rgba(176, 87, 3, 0.08);
     border: 1px solid rgba(176, 87, 3, 0.2);
-    border-radius: 8px;
-    padding: 6px 8px;
+    border-radius: 10px;
+    padding: 10px 12px;
     text-align: center;
 }
 
 .stat-label {
-    font-size: 10px;
+    font-size: 11px;
     color: rgba(128, 128, 128, 0.75);
-    margin-bottom: 2px;
+    margin-bottom: 4px;
     font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: 0.03em;
+    letter-spacing: 0.04em;
 }
 
 .stat-avg {
-    font-size: 16px;
+    font-size: 20px;
     font-weight: 700;
     color: #b05703;
     line-height: 1.1;
+}
+
+.stat-sub {
+    font-size: 10px;
+    color: rgba(128, 128, 128, 0.6);
+    margin-top: 2px;
 }
 
 .pickem-comments {
@@ -624,6 +671,12 @@ const infoModalTeamNumber = computed(() => infoModalSide.value === 'candidate' ?
     color: #b05703;
     text-transform: uppercase;
     letter-spacing: 0.05em;
+}
+
+.comment-match {
+    font-size: 10px;
+    color: rgba(128, 128, 128, 0.6);
+    margin-left: auto;
 }
 
 .comment-text {

--- a/src/views/PickEmView.vue
+++ b/src/views/PickEmView.vue
@@ -253,11 +253,51 @@ watch(compareAgainst, async (teamNumber) => {
 });
 
 // One entry per matchup side, so the template renders both with a single
-// v-for instead of duplicating the card/stats/pit markup twice.
+// v-for instead of duplicating the card/comments/pit markup twice.
 const matchupSides = computed(() => [
     { teamNumber: candidate.value, team: candidateTeam.value, data: candidateData.value },
     { teamNumber: compareAgainst.value, team: compareTeam.value, data: compareData.value }
 ]);
+
+// ─── Compare Stats modal ──────────────────────────────────────────────────
+// Stats/comments/pit data live behind this modal (rather than always
+// inline) specifically so the two picker cards above stay short enough to
+// both fit on screen at once on mobile without scrolling — see issue #45
+// follow-up.
+
+const showCompareModal = ref(false);
+
+// Close automatically when a winner is picked and a new matchup loads —
+// otherwise the modal would keep showing the previous pair's stats.
+watch(candidate, () => { showCompareModal.value = false; });
+
+// Merges each side's independently-computed stat lists into one row per
+// label so the modal can render a single side-by-side table instead of two
+// separate grids — the two teams' stat schemas are normally identical
+// (same match-scouting fields), but a team with zero scouted matches
+// returns an empty list, hence the '—' fallback below.
+const compareStatRows = computed(() => {
+    if (!candidateData.value || !compareData.value) return [];
+
+    const leftFlags = computeFlagStats(candidateData.value.stats);
+    const rightFlags = computeFlagStats(compareData.value.stats);
+    const leftBasic = computeBasicStats(candidateData.value.stats);
+    const rightBasic = computeBasicStats(compareData.value.stats);
+
+    const toRows = (leftList, rightList, formatValue) => {
+        const labels = [...new Set([...leftList.map((s) => s.label), ...rightList.map((s) => s.label)])];
+        return labels.map((label) => ({
+            label,
+            left: formatValue(leftList.find((s) => s.label === label)),
+            right: formatValue(rightList.find((s) => s.label === label))
+        }));
+    };
+
+    return [
+        ...toRows(leftFlags, rightFlags, (s) => (s ? `${s.pct}%` : '—')),
+        ...toRows(leftBasic, rightBasic, (s) => s?.avg ?? '—')
+    ];
+});
 </script>
 
 <template>
@@ -292,43 +332,71 @@ const matchupSides = computed(() => [
                             <div class="pickem-card-number">{{ side.team.team_number }}</div>
                             <div class="pickem-card-name">{{ side.team.name }}</div>
                         </button>
-
-                        <div class="data-tile pickem-info-card">
-                            <div v-if="!side.data" class="pickem-no-data">Loading stats…</div>
-                            <template v-else>
-                                <div v-if="side.data.stats.length > 0" class="pickem-stats-grid">
-                                    <div v-for="stat in computeFlagStats(side.data.stats)" :key="stat.label"
-                                        class="pickem-stat">
-                                        <div class="stat-label">{{ stat.label }}</div>
-                                        <div class="stat-avg">{{ stat.pct }}%</div>
-                                    </div>
-                                    <div v-for="stat in computeBasicStats(side.data.stats)" :key="stat.label"
-                                        class="pickem-stat">
-                                        <div class="stat-label">{{ stat.label }}</div>
-                                        <div class="stat-avg">{{ stat.avg }}</div>
-                                    </div>
-                                </div>
-                                <div v-else class="pickem-no-data">No match data available.</div>
-
-                                <ul v-if="side.data.comments.length > 0" class="pickem-comments">
-                                    <li v-for="(comment, cIdx) in side.data.comments" :key="cIdx" class="pickem-comment">
-                                        <div class="comment-meta">
-                                            <span class="comment-author">{{ comment.author }}</span>
-                                            <span class="comment-source-badge">{{ comment.source }}</span>
-                                        </div>
-                                        <p class="comment-text">{{ comment.comment }}</p>
-                                    </li>
-                                </ul>
-                            </template>
-                        </div>
-
-                        <PitScoutingSection :team-number="side.teamNumber"></PitScoutingSection>
                     </div>
 
                     <div v-if="idx === 0" class="pickem-vs">VS</div>
                 </template>
             </div>
+
+            <div class="pickem-compare-row">
+                <button type="button" class="pickem-compare-button" :disabled="!candidateData || !compareData"
+                    @click="showCompareModal = true">
+                    Compare Stats
+                </button>
+            </div>
         </template>
+
+        <div v-if="showCompareModal" class="pickem-modal-overlay" @click.self="showCompareModal = false">
+            <div class="pickem-modal" role="dialog" aria-modal="true" aria-label="Compare teams">
+                <div class="pickem-modal-header">
+                    <h2>{{ candidateTeam?.team_number }} vs {{ compareTeam?.team_number }}</h2>
+                    <button type="button" class="pickem-modal-close" @click="showCompareModal = false"
+                        aria-label="Close">✕</button>
+                </div>
+
+                <div class="pickem-modal-body">
+                    <table v-if="compareStatRows.length > 0" class="pickem-compare-table">
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th>{{ candidateTeam?.team_number }} - {{ candidateTeam?.name }}</th>
+                                <th>{{ compareTeam?.team_number }} - {{ compareTeam?.name }}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="row in compareStatRows" :key="row.label">
+                                <td class="compare-row-label">{{ row.label }}</td>
+                                <td>{{ row.left }}</td>
+                                <td>{{ row.right }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p v-else class="pickem-no-data">No match data available for either team.</p>
+
+                    <div class="pickem-compare-comments">
+                        <div v-for="side in matchupSides" :key="`comments-${side.teamNumber}`"
+                            class="pickem-compare-comments-col">
+                            <h3>{{ side.team?.team_number }} Comments</h3>
+                            <ul v-if="side.data?.comments.length > 0" class="pickem-comments">
+                                <li v-for="(comment, cIdx) in side.data.comments" :key="cIdx" class="pickem-comment">
+                                    <div class="comment-meta">
+                                        <span class="comment-author">{{ comment.author }}</span>
+                                        <span class="comment-source-badge">{{ comment.source }}</span>
+                                    </div>
+                                    <p class="comment-text">{{ comment.comment }}</p>
+                                </li>
+                            </ul>
+                            <p v-else class="pickem-no-data">No comments yet.</p>
+                        </div>
+                    </div>
+
+                    <div class="pickem-compare-pit">
+                        <PitScoutingSection v-for="side in matchupSides" :key="`pit-${side.teamNumber}`"
+                            :team-number="side.teamNumber"></PitScoutingSection>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -438,49 +506,126 @@ const matchupSides = computed(() => [
     text-align: center;
 }
 
-.pickem-info-card {
-    width: 100%;
-    margin: 0;
-    padding: 14px;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
 .pickem-no-data {
     font-size: 13px;
     color: rgba(128, 128, 128, 0.6);
     font-style: italic;
 }
 
-.pickem-stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(85px, 1fr));
-    gap: 8px;
+.pickem-compare-row {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
 }
 
-.pickem-stat {
-    background: rgba(176, 87, 3, 0.08);
-    border: 1px solid rgba(176, 87, 3, 0.2);
+.pickem-compare-button {
+    padding: 10px 20px;
     border-radius: 8px;
-    padding: 6px 8px;
-    text-align: center;
+    border: none;
+    background-color: var(--accent-color);
+    color: var(--primary-text-color);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 600;
 }
 
-.stat-label {
-    font-size: 10px;
-    color: rgba(128, 128, 128, 0.75);
-    margin-bottom: 2px;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
+.pickem-compare-button:hover:not(:disabled) {
+    background-color: var(--header-hover-color);
 }
 
-.stat-avg {
-    font-size: 16px;
-    font-weight: 700;
-    color: #b05703;
-    line-height: 1.1;
+.pickem-compare-button:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
+.pickem-modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+}
+
+.pickem-modal {
+    width: 100%;
+    max-width: 640px;
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--tile-background-color);
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.pickem-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 20px;
+    border-bottom: 1px solid rgba(128, 128, 128, 0.25);
+}
+
+.pickem-modal-header h2 {
+    margin: 0;
+    font-size: 18px;
+}
+
+.pickem-modal-close {
+    border: none;
+    background: transparent;
+    color: var(--primary-text-color);
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 4px 8px;
+}
+
+.pickem-modal-body {
+    padding: 16px 20px 20px;
+    overflow-y: auto;
+}
+
+.pickem-compare-table {
+    width: 100%;
+    box-shadow: none;
+    margin-bottom: 20px;
+}
+
+.compare-row-label {
+    text-align: left;
+    font-weight: 600;
+}
+
+.pickem-compare-comments {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-bottom: 20px;
+}
+
+.pickem-compare-comments-col {
+    flex: 1 1 220px;
+    min-width: 0;
+}
+
+.pickem-compare-comments-col h3 {
+    font-size: 14px;
+    margin-bottom: 8px;
+}
+
+.pickem-compare-pit {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.pickem-compare-pit > * {
+    flex: 1 1 260px;
+    min-width: 0;
 }
 
 .pickem-comments {
@@ -531,8 +676,47 @@ const matchupSides = computed(() => [
 }
 
 @media (max-width: 700px) {
+    /* Both cards need to stay in view together without scrolling, so they
+       stay side-by-side (never stacked) and shrink to fit instead — the
+       heavier stats/comments/pit content that used to sit inline under each
+       card now lives behind the Compare Stats modal for exactly this
+       reason. */
     .pickem-matchup {
-        flex-direction: column;
+        flex-wrap: nowrap;
+        gap: 10px;
+    }
+
+    .pickem-column {
+        width: auto;
+        max-width: none;
+        flex: 1 1 0;
+        min-width: 0;
+        gap: 8px;
+    }
+
+    .pickem-vs {
+        flex-shrink: 0;
+        margin-top: 40px;
+        font-size: 16px;
+    }
+
+    .pickem-card {
+        padding: 10px;
+    }
+
+    .pickem-card-number {
+        font-size: 18px;
+        margin-top: 8px;
+    }
+
+    .pickem-card-name {
+        font-size: 12px;
+    }
+
+    .pickem-compare-table th,
+    .pickem-compare-table td {
+        padding: 8px 6px;
+        font-size: 0.85em;
     }
 }
 </style>

--- a/src/views/PickEmView.vue
+++ b/src/views/PickEmView.vue
@@ -259,45 +259,23 @@ const matchupSides = computed(() => [
     { teamNumber: compareAgainst.value, team: compareTeam.value, data: compareData.value }
 ]);
 
-// ─── Compare Stats modal ──────────────────────────────────────────────────
+// ─── Per-team "More Info" modal ────────────────────────────────────────────
 // Stats/comments/pit data live behind this modal (rather than always
 // inline) specifically so the two picker cards above stay short enough to
 // both fit on screen at once on mobile without scrolling — see issue #45
-// follow-up.
+// follow-up. It shows one team at a time (a side-by-side comparison layout
+// doesn't have room to work on a narrow screen), opened via a "More Info"
+// button under whichever card the user taps.
 
-const showCompareModal = ref(false);
+const infoModalSide = ref<'candidate' | 'compare' | null>(null);
 
 // Close automatically when a winner is picked and a new matchup loads —
-// otherwise the modal would keep showing the previous pair's stats.
-watch(candidate, () => { showCompareModal.value = false; });
+// otherwise the modal would keep showing a team that's no longer on screen.
+watch(candidate, () => { infoModalSide.value = null; });
 
-// Merges each side's independently-computed stat lists into one row per
-// label so the modal can render a single side-by-side table instead of two
-// separate grids — the two teams' stat schemas are normally identical
-// (same match-scouting fields), but a team with zero scouted matches
-// returns an empty list, hence the '—' fallback below.
-const compareStatRows = computed(() => {
-    if (!candidateData.value || !compareData.value) return [];
-
-    const leftFlags = computeFlagStats(candidateData.value.stats);
-    const rightFlags = computeFlagStats(compareData.value.stats);
-    const leftBasic = computeBasicStats(candidateData.value.stats);
-    const rightBasic = computeBasicStats(compareData.value.stats);
-
-    const toRows = (leftList, rightList, formatValue) => {
-        const labels = [...new Set([...leftList.map((s) => s.label), ...rightList.map((s) => s.label)])];
-        return labels.map((label) => ({
-            label,
-            left: formatValue(leftList.find((s) => s.label === label)),
-            right: formatValue(rightList.find((s) => s.label === label))
-        }));
-    };
-
-    return [
-        ...toRows(leftFlags, rightFlags, (s) => (s ? `${s.pct}%` : '—')),
-        ...toRows(leftBasic, rightBasic, (s) => s?.avg ?? '—')
-    ];
-});
+const infoModalTeam = computed(() => infoModalSide.value === 'candidate' ? candidateTeam.value : compareTeam.value);
+const infoModalData = computed(() => infoModalSide.value === 'candidate' ? candidateData.value : compareData.value);
+const infoModalTeamNumber = computed(() => infoModalSide.value === 'candidate' ? candidate.value : compareAgainst.value);
 </script>
 
 <template>
@@ -332,68 +310,54 @@ const compareStatRows = computed(() => {
                             <div class="pickem-card-number">{{ side.team.team_number }}</div>
                             <div class="pickem-card-name">{{ side.team.name }}</div>
                         </button>
+                        <button type="button" class="pickem-more-info-button" :disabled="!side.data"
+                            @click="infoModalSide = idx === 0 ? 'candidate' : 'compare'">
+                            More Info
+                        </button>
                     </div>
 
                     <div v-if="idx === 0" class="pickem-vs">VS</div>
                 </template>
             </div>
-
-            <div class="pickem-compare-row">
-                <button type="button" class="pickem-compare-button" :disabled="!candidateData || !compareData"
-                    @click="showCompareModal = true">
-                    Compare Stats
-                </button>
-            </div>
         </template>
 
-        <div v-if="showCompareModal" class="pickem-modal-overlay" @click.self="showCompareModal = false">
-            <div class="pickem-modal" role="dialog" aria-modal="true" aria-label="Compare teams">
+        <div v-if="infoModalSide" class="pickem-modal-overlay" @click.self="infoModalSide = null">
+            <div class="pickem-modal" role="dialog" aria-modal="true"
+                :aria-label="`Team ${infoModalTeamNumber} info`">
                 <div class="pickem-modal-header">
-                    <h2>{{ candidateTeam?.team_number }} vs {{ compareTeam?.team_number }}</h2>
-                    <button type="button" class="pickem-modal-close" @click="showCompareModal = false"
+                    <h2>{{ infoModalTeam?.team_number }} - {{ infoModalTeam?.name }}</h2>
+                    <button type="button" class="pickem-modal-close" @click="infoModalSide = null"
                         aria-label="Close">✕</button>
                 </div>
 
                 <div class="pickem-modal-body">
-                    <table v-if="compareStatRows.length > 0" class="pickem-compare-table">
-                        <thead>
-                            <tr>
-                                <th></th>
-                                <th>{{ candidateTeam?.team_number }} - {{ candidateTeam?.name }}</th>
-                                <th>{{ compareTeam?.team_number }} - {{ compareTeam?.name }}</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr v-for="row in compareStatRows" :key="row.label">
-                                <td class="compare-row-label">{{ row.label }}</td>
-                                <td>{{ row.left }}</td>
-                                <td>{{ row.right }}</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                    <p v-else class="pickem-no-data">No match data available for either team.</p>
-
-                    <div class="pickem-compare-comments">
-                        <div v-for="side in matchupSides" :key="`comments-${side.teamNumber}`"
-                            class="pickem-compare-comments-col">
-                            <h3>{{ side.team?.team_number }} Comments</h3>
-                            <ul v-if="side.data?.comments.length > 0" class="pickem-comments">
-                                <li v-for="(comment, cIdx) in side.data.comments" :key="cIdx" class="pickem-comment">
-                                    <div class="comment-meta">
-                                        <span class="comment-author">{{ comment.author }}</span>
-                                        <span class="comment-source-badge">{{ comment.source }}</span>
-                                    </div>
-                                    <p class="comment-text">{{ comment.comment }}</p>
-                                </li>
-                            </ul>
-                            <p v-else class="pickem-no-data">No comments yet.</p>
+                    <div v-if="infoModalData?.stats.length > 0" class="pickem-stats-grid">
+                        <div v-for="stat in computeFlagStats(infoModalData.stats)" :key="stat.label"
+                            class="pickem-stat">
+                            <div class="stat-label">{{ stat.label }}</div>
+                            <div class="stat-avg">{{ stat.pct }}%</div>
+                        </div>
+                        <div v-for="stat in computeBasicStats(infoModalData.stats)" :key="stat.label"
+                            class="pickem-stat">
+                            <div class="stat-label">{{ stat.label }}</div>
+                            <div class="stat-avg">{{ stat.avg }}</div>
                         </div>
                     </div>
+                    <p v-else class="pickem-no-data">No match data available.</p>
 
-                    <div class="pickem-compare-pit">
-                        <PitScoutingSection v-for="side in matchupSides" :key="`pit-${side.teamNumber}`"
-                            :team-number="side.teamNumber"></PitScoutingSection>
-                    </div>
+                    <h3 class="pickem-modal-section-title">Comments</h3>
+                    <ul v-if="infoModalData?.comments.length > 0" class="pickem-comments">
+                        <li v-for="(comment, cIdx) in infoModalData.comments" :key="cIdx" class="pickem-comment">
+                            <div class="comment-meta">
+                                <span class="comment-author">{{ comment.author }}</span>
+                                <span class="comment-source-badge">{{ comment.source }}</span>
+                            </div>
+                            <p class="comment-text">{{ comment.comment }}</p>
+                        </li>
+                    </ul>
+                    <p v-else class="pickem-no-data">No comments yet.</p>
+
+                    <PitScoutingSection :team-number="infoModalTeamNumber"></PitScoutingSection>
                 </div>
             </div>
         </div>
@@ -512,14 +476,9 @@ const compareStatRows = computed(() => {
     font-style: italic;
 }
 
-.pickem-compare-row {
-    display: flex;
-    justify-content: center;
-    margin-top: 20px;
-}
-
-.pickem-compare-button {
-    padding: 10px 20px;
+.pickem-more-info-button {
+    width: 100%;
+    padding: 8px 16px;
     border-radius: 8px;
     border: none;
     background-color: var(--accent-color);
@@ -529,11 +488,11 @@ const compareStatRows = computed(() => {
     font-weight: 600;
 }
 
-.pickem-compare-button:hover:not(:disabled) {
+.pickem-more-info-button:hover:not(:disabled) {
     background-color: var(--header-hover-color);
 }
 
-.pickem-compare-button:disabled {
+.pickem-more-info-button:disabled {
     opacity: 0.6;
     cursor: default;
 }
@@ -541,7 +500,9 @@ const compareStatRows = computed(() => {
 .pickem-modal-overlay {
     position: fixed;
     inset: 0;
-    z-index: 100;
+    /* Above NavBar.vue's fixed header (z-index: 9999) so the modal's own
+       header/close button never end up hidden underneath it. */
+    z-index: 10000;
     background: rgba(0, 0, 0, 0.6);
     display: flex;
     align-items: center;
@@ -589,43 +550,40 @@ const compareStatRows = computed(() => {
     overflow-y: auto;
 }
 
-.pickem-compare-table {
-    width: 100%;
-    box-shadow: none;
-    margin-bottom: 20px;
-}
-
-.compare-row-label {
-    text-align: left;
-    font-weight: 600;
-}
-
-.pickem-compare-comments {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
-    margin-bottom: 20px;
-}
-
-.pickem-compare-comments-col {
-    flex: 1 1 220px;
-    min-width: 0;
-}
-
-.pickem-compare-comments-col h3 {
+.pickem-modal-section-title {
     font-size: 14px;
+    margin: 20px 0 8px;
+}
+
+.pickem-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(85px, 1fr));
+    gap: 8px;
     margin-bottom: 8px;
 }
 
-.pickem-compare-pit {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
+.pickem-stat {
+    background: rgba(176, 87, 3, 0.08);
+    border: 1px solid rgba(176, 87, 3, 0.2);
+    border-radius: 8px;
+    padding: 6px 8px;
+    text-align: center;
 }
 
-.pickem-compare-pit > * {
-    flex: 1 1 260px;
-    min-width: 0;
+.stat-label {
+    font-size: 10px;
+    color: rgba(128, 128, 128, 0.75);
+    margin-bottom: 2px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.stat-avg {
+    font-size: 16px;
+    font-weight: 700;
+    color: #b05703;
+    line-height: 1.1;
 }
 
 .pickem-comments {
@@ -679,7 +637,7 @@ const compareStatRows = computed(() => {
     /* Both cards need to stay in view together without scrolling, so they
        stay side-by-side (never stacked) and shrink to fit instead — the
        heavier stats/comments/pit content that used to sit inline under each
-       card now lives behind the Compare Stats modal for exactly this
+       card now lives behind the per-team More Info modal for exactly this
        reason. */
     .pickem-matchup {
         flex-wrap: nowrap;
@@ -713,9 +671,8 @@ const compareStatRows = computed(() => {
         font-size: 12px;
     }
 
-    .pickem-compare-table th,
-    .pickem-compare-table td {
-        padding: 8px 6px;
+    .pickem-more-info-button {
+        padding: 8px 10px;
         font-size: 0.85em;
     }
 }

--- a/src/views/ScoutScheduleView.vue
+++ b/src/views/ScoutScheduleView.vue
@@ -2,6 +2,7 @@
 // @ts-nocheck
 
 import CollapsibleSection from "@/components/CollapsibleSection.vue";
+import SearchableDropdown from "@/components/SearchableDropdown.vue";
 
 import { useEventStore } from "@/stores/event-store";
 import { useAuthStore } from "@/stores/auth-store";
@@ -82,15 +83,12 @@ import { queryScoutAssignments, queryScoutAssignmentsForUser, assignScout, assig
                                     :class="[slotKey.startsWith('red') ? 'red-cell' : 'blue-cell', cellInFillRange(rowIndex, colIndex) ? 'fill-range' : '']"
                                     :data-row="rowIndex" :data-col="colIndex"
                                     @mouseover="onFillDragEnter(rowIndex, colIndex)">
-                                    <select class="assignment-select"
-                                        :value="adminScoutFor(match.match_number, slotKey)"
+                                    <SearchableDropdown class="assignment-select"
+                                        :class="{ 'assignment-select--filled': !!adminScoutFor(match.match_number, slotKey) }"
                                         :style="scoutSelectStyle(adminScoutFor(match.match_number, slotKey))"
-                                        @change="onAdminAssignChange(match.match_number, slotKey, $event.target.value)">
-                                        <option value="">Unassigned</option>
-                                        <option v-for="person in assignableUsers" :key="person.user_id" :value="person.user_id">
-                                            {{ person.name || 'Unnamed user' }}
-                                        </option>
-                                    </select>
+                                        :choices="scoutChoices" :model-value="adminScoutFor(match.match_number, slotKey)"
+                                        @update:modelValue="onAdminAssignChange(match.match_number, slotKey, $event)">
+                                    </SearchableDropdown>
                                     <div class="fill-handle" @mousedown="startFillDrag(rowIndex, colIndex, $event)"></div>
                                 </td>
                             </tr>
@@ -166,6 +164,15 @@ export default {
             return this.people
                 .filter((person) => person.role !== 'observer')
                 .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+        },
+        // Includes the "Unassigned" option as a real choice (key '', matching
+        // adminScoutFor's empty-string default) rather than a placeholder, so
+        // it displays and searches like any other choice.
+        scoutChoices() {
+            return [
+                { key: '', text: 'Unassigned' },
+                ...this.assignableUsers.map((person) => ({ key: person.user_id, text: person.name || 'Unnamed user' }))
+            ];
         }
     },
     methods: {
@@ -458,27 +465,24 @@ export default {
     flex-shrink: 0;
 }
 
+/* scoutSelectStyle() sets this wrapper's background inline (falls through to
+   the SearchableDropdown component's root element); the input itself stays
+   transparent (see SearchableDropdown.vue) so that color shows through. */
 .assignment-select {
     display: block;
-    width: 100%;
+    border-radius: 6px;
+}
+
+.assignment-select :deep(.searchable-dropdown-input) {
     padding: 10px 8px;
     font-size: 1rem;
-    border-radius: 6px;
-    border: 1px solid rgba(128, 128, 128, 0.35);
-    background-color: transparent;
-    color: var(--primary-text-color);
-    cursor: pointer;
 }
 
-.assignment-select:hover {
-    border-color: rgba(128, 128, 128, 0.6);
-}
-
-/* When a scout is assigned, scoutSelectStyle() sets an inline
-   background/text color per-scout, overriding these defaults. */
-.assignment-select option {
-    color: initial;
-    background-color: initial;
+/* When a scout is assigned, scoutSelectStyle() also sets white text — the
+   input's own explicit `color` declaration would otherwise win over the
+   inherited color from this wrapper. */
+.assignment-select--filled :deep(.searchable-dropdown-input) {
+    color: #fff;
 }
 
 .assignment-cell {

--- a/src/views/StrategyView.vue
+++ b/src/views/StrategyView.vue
@@ -52,6 +52,8 @@ import "@material/web/button/filled-button";
                     turn on Manual Team Selection to pick teams yourself.</p>
             </div>
 
+            <p class="color-hint">💡 Click a team's color swatch to choose a different color.</p>
+
             <h2>Red Alliance</h2>
             <div class="data-tile red-alliance">
                 <div class="autopath-preview-selectors">
@@ -122,8 +124,8 @@ import "@material/web/button/filled-button";
                             :points="strategyMode === 'autoEdit' ? autoEditPoints : []"
                             :display-alliance="autoEditAlliance" :time-gradient="strategyMode === 'autoEdit'"
                             :robot-photo-url="strategyMode === 'autoEdit' ? robotPhotoUrls[autoEditSlot] : null"
-                            large="true" :playing="isPlaying" @update:points="autoEditPoints = $event"
-                            @finished="isPlaying = false"></AutoPathCanvas>
+                            :station-labels="stationLabels" large="true" :playing="isPlaying"
+                            @update:points="autoEditPoints = $event" @finished="isPlaying = false"></AutoPathCanvas>
                     </div>
 
                     <div class="autopath-bottom-controls">
@@ -152,7 +154,10 @@ import "@material/web/button/filled-button";
                     <div class="autopath-side-by-side">
                         <div class="autopath-side-column">
                             <div v-for="slot in [0, 1, 2]" :key="slot" class="autopath-slot-controls">
-                                <span class="autopath-preview-swatch" :style="{ backgroundColor: slotColor(slot) }"></span>
+                                <div class="autopath-slot-header">
+                                    <span class="autopath-preview-swatch" :style="{ backgroundColor: slotColor(slot) }"></span>
+                                    <span class="autopath-slot-team">{{ teamAtSlot(slot)?.text ?? 'Unassigned' }}</span>
+                                </div>
                                 <Dropdown :choices="autoPathChoices[slot] ?? []" :model-value="selectedAutoPathIndex[slot]"
                                     @update:modelValue="onAutoPathChoiceChange(slot, $event)"></Dropdown>
                                 <Dropdown :choices="SIDE_CHOICES" v-model="selectedSideIndex[slot]"></Dropdown>
@@ -163,7 +168,10 @@ import "@material/web/button/filled-button";
 
                         <div class="autopath-side-column">
                             <div v-for="slot in [3, 4, 5]" :key="slot" class="autopath-slot-controls">
-                                <span class="autopath-preview-swatch" :style="{ backgroundColor: slotColor(slot) }"></span>
+                                <div class="autopath-slot-header">
+                                    <span class="autopath-preview-swatch" :style="{ backgroundColor: slotColor(slot) }"></span>
+                                    <span class="autopath-slot-team">{{ teamAtSlot(slot)?.text ?? 'Unassigned' }}</span>
+                                </div>
                                 <Dropdown :choices="autoPathChoices[slot] ?? []" :model-value="selectedAutoPathIndex[slot]"
                                     @update:modelValue="onAutoPathChoiceChange(slot, $event)"></Dropdown>
                                 <Dropdown :choices="SIDE_CHOICES" v-model="selectedSideIndex[slot]"></Dropdown>
@@ -348,7 +356,14 @@ export default {
             }
         },
         slotColor(slot: int) {
-            return COLOR_CHOICES[this.slotColorIndex[slot]]?.hex ?? '#ff8c00';
+            const choice = COLOR_CHOICES[this.slotColorIndex[slot]];
+            if (!choice) return '#ff8c00';
+            // 'white' is unusable against light mode's white/near-white
+            // canvas and field backgrounds — draw it as black there instead,
+            // matching ColorSwatchPicker's swatch-only override so what the
+            // picker shows is also what actually gets drawn.
+            if (choice.key === 'white' && !this.deviceViewMode?.darkMode) return '#000000';
+            return choice.hex;
         },
         onAutoPathChoiceChange(slot: int, choiceIdx: int) {
             this.selectedAutoPathIndex[slot] = choiceIdx;
@@ -504,6 +519,18 @@ export default {
                 text: `${labels[slot]} — ${this.teamAtSlot(slot)?.text ?? 'Unassigned'}`
             }));
         },
+        // Big on-field driver-station labels (see AutoPathCanvas's
+        // stationLabels prop) — skips unassigned slots so an empty alliance
+        // spot doesn't clutter the field with a placeholder.
+        stationLabels() {
+            return [0, 1, 2, 3, 4, 5]
+                .filter((slot) => this.teamNumbers[slot])
+                .map((slot) => ({
+                    slot,
+                    text: String(this.teamNumbers[slot]),
+                    color: this.slotColor(slot)
+                }));
+        },
         autoEditAlliance() {
             return this.autoEditSlot < 3 ? allianceRed : allianceBlue;
         }
@@ -539,6 +566,15 @@ export default {
 
 .blue-alliance {
     border: 2px solid blue;
+}
+
+/* The global .data-tile class sets overflow: auto, which would otherwise
+   clip (and add a scrollbar around) ColorSwatchPicker's expanded palette
+   popup — these two tiles only ever hold that picker plus a couple of
+   dropdowns, nothing that actually needs to scroll. */
+.data-tile.red-alliance,
+.data-tile.blue-alliance {
+    overflow: visible;
 }
 
 .autopath-preview-heading {
@@ -584,14 +620,34 @@ export default {
     font-weight: bold;
 }
 
+.color-hint {
+    font-size: 13px;
+    color: rgba(128, 128, 128, 0.85);
+    margin: -4px 0 12px;
+}
+
 .strategy-mode-toggle {
     display: flex;
     gap: 10px;
     margin-bottom: 24px;
 }
 
-.strategy-mode-toggle md-filled-button.mode-inactive {
+.strategy-mode-toggle md-filled-button.mode-inactive,
+.tool-toggle md-filled-button.mode-inactive {
     --md-filled-button-container-color: rgba(128, 128, 128, 0.4);
+}
+
+.whiteboard-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 14px;
+    margin-bottom: 20px;
+}
+
+.tool-toggle {
+    display: flex;
+    gap: 8px;
 }
 
 .autopath-form-row {
@@ -654,6 +710,16 @@ export default {
     display: flex;
     flex-direction: column;
     gap: 10px;
+}
+
+.autopath-slot-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.autopath-slot-team {
+    font-weight: 600;
 }
 
 @media (max-width: 1000px) {


### PR DESCRIPTION
closes #45

Rewrites Dropdown.vue to gain SearchableDropdown's search-filter behavior
while keeping its index-based modelValue contract intact, so every scouting
form, auto-path picker, and data-visualization dropdown becomes searchable
with no per-call-site changes. Also converts the account role picker and the
schedule page's per-cell scout-assignment picker to SearchableDropdown, and
sizes both components' inputs to fit their widest choice so selected text
never gets clipped.

Adds whiteboard quality-of-life features (clear all strokes, undo, an
eraser tool), turns the alliance color picker into a click-to-expand
palette with a light-mode-safe black swap for the white swatch (applied to
actual strokes/labels too, not just the picker), and overlays team numbers
next to their driver stations on the strategy preview field