### PR TITLE
Add in-app TBA sync and OPR/DPR display

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,10 @@ npm install
 cd util
 uv sync
 ```
+4. Set the `TBA_API_KEY` secret on the linked Supabase project — required for the `tba-proxy` Edge Function (in-app TBA sync and OPR/DPR display) to work. Use the same key as `util/private_credentials.json`'s `tba.api_key`:
+```bash
+supabase secrets set TBA_API_KEY=<your-tba-api-key>
+```
 
 ## Development 
 

--- a/src/components/PicklistRow.vue
+++ b/src/components/PicklistRow.vue
@@ -2,11 +2,12 @@
 // @ts-nocheck
 import type { TeamEntry } from '@/stores/picklist-store';
 import type { TeamTierStats } from '@/lib/picklist-query';
-import { computeBasicStats, computeFlagStats } from '@/lib/picklist-stats';
+import { computeBasicStats, computeFlagStats, computeTbaStats } from '@/lib/picklist-stats';
 
 defineProps<{
     rowId: string;
     team: TeamEntry;
+    eventId: string;
     position: number;
     showDragHandle: boolean;
     showVoteStats: boolean;
@@ -91,6 +92,19 @@ function formatAvgRank(avgRank: number) {
                     <div class="picklist-detail-photo" v-if="team.photo_url">
                         <img :src="team.photo_url" :alt="`Team ${team.team_number} robot (full)`"
                             class="picklist-full-photo" />
+                    </div>
+
+                    <!-- TBA OPR/DPR — independent of scouted match data, so shown whenever cached (issue #26) -->
+                    <div class="picklist-detail-section" v-if="computeTbaStats(eventId, team.team_number).length > 0">
+                        <h3 class="picklist-detail-heading">TBA Stats</h3>
+                        <div class="picklist-stats-grid">
+                            <div v-for="stat in computeTbaStats(eventId, team.team_number)" :key="stat.label"
+                                class="picklist-stat-card">
+                                <div class="stat-label">{{ stat.label }}</div>
+                                <div class="stat-avg">{{ stat.avg }}</div>
+                                <div class="stat-sub">{{ stat.sub }}</div>
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Stats -->

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -35,6 +35,10 @@ export const sideRight = "right";
 // Offline queue
 export const offlineQueueKey = "greyscout_offline_queue";
 
+// TBA integration
+export const tbaProxyFunction = "tba-proxy";
+export const tbaStatsCacheKey = "greyscout_tba_stats_cache";
+
 // Database columns
 export const teamNumberColumn = "prematch_team_number";
 export const matchNumberColumn = "prematch_match_number";

--- a/src/lib/picklist-stats.ts
+++ b/src/lib/picklist-stats.ts
@@ -3,6 +3,8 @@
 // PicklistUnrankedCard.vue's expanded views so the two don't duplicate the
 // same field-derivation logic.
 
+import { getTeamTbaStats } from '@/lib/tba-cache';
+
 export function computeBasicStats(matchData: unknown[]) {
     if (!matchData.length) return [];
 
@@ -46,4 +48,17 @@ export function computeFlagStats(matchData: unknown[]) {
         const pct = (count / matchData.length) * 100;
         return { label, pct: pct.toFixed(0), count, total: matchData.length };
     });
+}
+
+// TBA OPR/DPR, read synchronously from the local cache (src/lib/tba-cache.ts)
+// — never fetched here. Empty until a "Refresh TBA Stats" action has run at
+// least once for this event.
+export function computeTbaStats(eventId: string, teamNumber: number) {
+    const stats = getTeamTbaStats(eventId, teamNumber);
+    if (!stats) return [];
+
+    const entries = [];
+    if (stats.opr != null) entries.push({ label: 'OPR', avg: stats.opr.toFixed(1), sub: 'via TBA' });
+    if (stats.dpr != null) entries.push({ label: 'DPR', avg: stats.dpr.toFixed(1), sub: 'via TBA' });
+    return entries;
 }

--- a/src/lib/tba-cache.ts
+++ b/src/lib/tba-cache.ts
@@ -1,0 +1,53 @@
+// @ts-nocheck
+// Ephemeral, client-side-only cache for TBA OPR/DPR stats — intentionally
+// never persisted to the DB (issue #26). Modeled on
+// offline-queue-store.ts's try/catch localStorage load/save pattern.
+// TBA's oprs endpoint returns every team at an event in one call, so this
+// caches per-event rather than per-team to actually minimize TBA requests.
+
+import { tbaStatsCacheKey } from '@/lib/constants';
+import { fetchEventOprDpr } from '@/lib/tba-query';
+
+function loadCache() {
+    try {
+        const raw = localStorage.getItem(tbaStatsCacheKey);
+        return raw ? JSON.parse(raw) : {};
+    } catch {
+        return {};
+    }
+}
+
+function saveCache(cache) {
+    try {
+        localStorage.setItem(tbaStatsCacheKey, JSON.stringify(cache));
+    } catch (e) {
+        console.warn('Failed to persist TBA stats cache:', e);
+    }
+}
+
+export function getCachedTbaStats(eventId) {
+    return loadCache()[eventId] ?? null;
+}
+
+export function setCachedTbaStats(eventId, stats) {
+    const cache = loadCache();
+    cache[eventId] = { fetchedAt: Date.now(), ...stats };
+    saveCache(cache);
+}
+
+export function getTeamTbaStats(eventId, teamNumber) {
+    const stats = getCachedTbaStats(eventId);
+    if (!stats) return null;
+
+    const opr = stats.oprs?.[teamNumber];
+    const dpr = stats.dprs?.[teamNumber];
+    if (opr == null && dpr == null) return null;
+
+    return { opr: opr ?? null, dpr: dpr ?? null };
+}
+
+export async function refreshTbaStats(eventId) {
+    const { oprs, dprs } = await fetchEventOprDpr(eventId);
+    setCachedTbaStats(eventId, { oprs, dprs });
+    return { oprs, dprs };
+}

--- a/src/lib/tba-query.ts
+++ b/src/lib/tba-query.ts
@@ -1,0 +1,58 @@
+// @ts-nocheck
+// Thin wrappers around the tba-proxy Supabase Edge Function, which holds the
+// TBA API key (and, for the schedule refresh, a service-role Supabase key)
+// server-side so neither ever reaches the browser.
+
+import { supabase } from '@/lib/supabase-client';
+import { tbaProxyFunction } from '@/lib/constants';
+
+async function describeFunctionError(error, data) {
+    if (data?.error) return data.error;
+    if (!error) return 'Unknown error';
+    try {
+        if (error.context && typeof error.context.json === 'function') {
+            const body = await error.context.json();
+            if (body?.error) return body.error;
+        }
+    } catch {
+        // Body wasn't JSON (or already consumed) — fall through to the generic message below.
+    }
+    return error.message ?? String(error);
+}
+
+export async function refreshEventSchedule(eventId) {
+    const { data, error } = await supabase.functions.invoke(tbaProxyFunction, {
+        body: { action: 'refresh_schedule', event_id: eventId }
+    });
+
+    if (error || data?.error) {
+        return { matchCount: 0, error: { message: await describeFunctionError(error, data) } };
+    }
+
+    return { matchCount: data?.matchCount ?? 0, error: null };
+}
+
+export async function fetchEventOprDpr(eventId) {
+    const { data, error } = await supabase.functions.invoke(tbaProxyFunction, {
+        body: { action: 'get_oprs', event_id: eventId }
+    });
+
+    if (error || data?.error) {
+        throw new Error(await describeFunctionError(error, data));
+    }
+
+    // TBA keys OPRs/DPRs by team key ("frc973") — normalize to bare team numbers.
+    const normalize = (byTeamKey) => {
+        const result = {};
+        Object.entries(byTeamKey ?? {}).forEach(([key, value]) => {
+            const teamNumber = Number(key.replace('frc', ''));
+            if (Number.isFinite(teamNumber)) result[teamNumber] = value;
+        });
+        return result;
+    };
+
+    return {
+        oprs: normalize(data?.oprs),
+        dprs: normalize(data?.dprs)
+    };
+}

--- a/src/views/AccountView.vue
+++ b/src/views/AccountView.vue
@@ -9,7 +9,9 @@ import SearchableDropdown from '@/components/SearchableDropdown.vue';
 import { supabase } from "@/lib/supabase-client";
 
 import { useAuthStore, roleRank } from "@/stores/auth-store";
+import { useEventStore } from "@/stores/event-store";
 import { fetchAllUsers, updateUserRole } from "@/lib/user-query";
+import { refreshEventSchedule } from "@/lib/tba-query";
 </script>
 
 <template>
@@ -18,6 +20,16 @@ import { fetchAllUsers, updateUserRole } from "@/lib/user-query";
             <h1>Profile</h1>
             <div>Name: {{ authStore.currentUserName || '(no name on file)' }}</div>
             <div>Role: {{ authStore.role }}</div>
+        </div>
+
+        <div class="user-tile" v-if="authStore.isLead">
+            <h1>Event Management</h1>
+            <div>Current event: {{ eventStore.eventName || eventStore.eventId }}</div>
+            <md-filled-button v-on:click="refreshEventData" :disabled="eventRefreshing" class="load-button">
+                {{ eventRefreshing ? 'Refreshing…' : 'Refresh Event Data' }}
+            </md-filled-button>
+            <p v-if="eventRefreshMessage" class="event-refresh-message">{{ eventRefreshMessage }}</p>
+            <p v-if="eventRefreshError" class="form-error">{{ eventRefreshError }}</p>
         </div>
 
         <div class="user-tile">
@@ -63,13 +75,32 @@ export default {
     data() {
         return {
             authStore: null,
+            eventStore: null,
             people: [],
             peopleLoaded: false,
             peopleError: "",
             pendingRole: {},
+            eventRefreshing: false,
+            eventRefreshMessage: "",
+            eventRefreshError: "",
         }
     },
     methods: {
+        async refreshEventData() {
+            this.eventRefreshing = true;
+            this.eventRefreshMessage = "";
+            this.eventRefreshError = "";
+
+            const { matchCount, error } = await refreshEventSchedule(this.eventStore.eventId);
+
+            if (error) {
+                this.eventRefreshError = error.message;
+            } else {
+                this.eventRefreshMessage = `Match schedule refreshed — ${matchCount} matches.`;
+            }
+
+            this.eventRefreshing = false;
+        },
         async loadPeople() {
             this.peopleLoaded = false;
             this.people = await fetchAllUsers();
@@ -125,7 +156,9 @@ export default {
     },
     async created() {
         this.authStore = useAuthStore();
+        this.eventStore = useEventStore();
         await this.authStore.checkUser();
+        await this.eventStore.updateEvent();
         await this.loadPeople();
     }
 }
@@ -154,6 +187,11 @@ export default {
 
 .form-error {
     color: #c0392b;
+}
+
+.event-refresh-message {
+    color: #2f8a2f;
+    font-size: 13px;
 }
 
 .role-select {

--- a/src/views/PickEmView.vue
+++ b/src/views/PickEmView.vue
@@ -6,7 +6,7 @@ import { usePicklistStore } from '@/stores/picklist-store';
 import { useAuthStore } from '@/stores/auth-store';
 import { useEventStore } from '@/stores/event-store';
 import { useOfflineQueueStore } from '@/stores/offline-queue-store';
-import { computeBasicStats, computeFlagStats } from '@/lib/picklist-stats';
+import { computeBasicStats, computeFlagStats, computeTbaStats } from '@/lib/picklist-stats';
 import PitScoutingSection from '@/components/PitScoutingSection.vue';
 
 const picklistStore = usePicklistStore();
@@ -338,6 +338,19 @@ const infoModalTeamNumber = computed(() => infoModalSide.value === 'candidate' ?
                     <div class="pickem-detail-photo" v-if="infoModalTeam?.photo_url">
                         <img :src="infoModalTeam.photo_url" :alt="`Team ${infoModalTeamNumber} robot (full)`"
                             class="pickem-full-photo" />
+                    </div>
+
+                    <!-- TBA OPR/DPR — independent of scouted match data, so shown whenever cached (issue #26) -->
+                    <div class="pickem-detail-section" v-if="computeTbaStats(eventId, infoModalTeamNumber).length > 0">
+                        <h3 class="pickem-detail-heading">TBA Stats</h3>
+                        <div class="pickem-stats-grid">
+                            <div v-for="stat in computeTbaStats(eventId, infoModalTeamNumber)" :key="stat.label"
+                                class="pickem-stat">
+                                <div class="stat-label">{{ stat.label }}</div>
+                                <div class="stat-avg">{{ stat.avg }}</div>
+                                <div class="stat-sub">{{ stat.sub }}</div>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="pickem-detail-section" v-if="infoModalData?.stats.length > 0">

--- a/src/views/PicklistView.vue
+++ b/src/views/PicklistView.vue
@@ -9,6 +9,7 @@ import { useEventStore } from '@/stores/event-store';
 import { useOfflineQueueStore } from '@/stores/offline-queue-store';
 import { useWatchlistStore } from '@/stores/watchlist-store';
 import { TIERS, TIER_GROUPS } from '@/lib/picklist-query';
+import { refreshTbaStats } from '@/lib/tba-cache';
 import PicklistRow from '@/components/PicklistRow.vue';
 import PicklistUnrankedCard from '@/components/PicklistUnrankedCard.vue';
 
@@ -208,6 +209,23 @@ async function refreshDemocratic() {
     isRefreshingDemocratic.value = false;
 }
 
+// ─── Refresh TBA Stats (issue #26) ────────────────────────────────────────────
+// Read-only pull (no DB write), so available to everyone, not just leads.
+
+const isRefreshingTbaStats = ref(false);
+const tbaStatsError = ref('');
+
+async function refreshTbaStatsForEvent() {
+    isRefreshingTbaStats.value = true;
+    tbaStatsError.value = '';
+    try {
+        await refreshTbaStats(eventId.value);
+    } catch (e) {
+        tbaStatsError.value = e.message ?? String(e);
+    }
+    isRefreshingTbaStats.value = false;
+}
+
 // ─── Reset Team List from Democratic ──────────────────────────────────────────
 
 async function resetTeamFromDemocratic() {
@@ -320,7 +338,12 @@ function toggleTierCollapse(group: string) {
             <div class="picklist-header">
                 <h1>Pick List</h1>
                 <div class="picklist-event-name">{{ eventStore.eventName }}</div>
+                <button type="button" class="picklist-reset-btn picklist-tba-refresh-btn" :disabled="isRefreshingTbaStats"
+                    title="Re-pull OPR/DPR from The Blue Alliance for this event" @click="refreshTbaStatsForEvent">
+                    {{ isRefreshingTbaStats ? 'Refreshing TBA Stats…' : '↻ Refresh TBA Stats' }}
+                </button>
             </div>
+            <p v-if="tbaStatsError" class="picklist-tba-error">{{ tbaStatsError }}</p>
 
             <!-- Tab bar -->
             <div class="picklist-tabs" role="tablist">
@@ -457,6 +480,7 @@ function toggleTierCollapse(group: string) {
                                 class="tier-section-body" @start="onDragStart" @end="onDragEnd" @change="saveList">
                                 <template #item="{ element: teamNumber, index }">
                                     <PicklistRow :row-id="`picklist-team-${teamNumber}`" :team="picklistStore.teamMap[teamNumber]"
+                                        :event-id="eventId"
                                         :position="groupRankOffset(group) + index + 1" :show-drag-handle="true" :show-vote-stats="showVoteStats"
                                         :tier-stats="tierStatsFor(teamNumber)" :show-picked="showPickedCheckbox"
                                         :is-picked="picklistStore.isTeamPicked(teamNumber)"
@@ -473,6 +497,7 @@ function toggleTierCollapse(group: string) {
                             <div v-else v-show="!isTierCollapsed(group)" class="tier-section-body tier-section-body--static">
                                 <PicklistRow v-for="(teamNumber, index) in picklistStore.activeSections[group]" :key="teamNumber"
                                     :row-id="`picklist-team-demo-${teamNumber}`" :team="picklistStore.teamMap[teamNumber]"
+                                    :event-id="eventId"
                                     :position="groupRankOffset(group) + index + 1" :show-drag-handle="false" :show-vote-stats="showVoteStats"
                                     :tier-stats="tierStatsFor(teamNumber)" :show-picked="showPickedCheckbox"
                                     :is-picked="picklistStore.isTeamPicked(teamNumber)"
@@ -566,6 +591,16 @@ function toggleTierCollapse(group: string) {
     font-size: 14px;
     color: rgba(128, 128, 128, 0.8);
     font-style: italic;
+}
+
+.picklist-tba-refresh-btn {
+    margin-left: auto;
+}
+
+.picklist-tba-error {
+    color: #d32f2f;
+    font-size: 13px;
+    margin: 4px 0 0;
 }
 
 /* ── Tabs ── */

--- a/src/views/TeamAnalysisView.vue
+++ b/src/views/TeamAnalysisView.vue
@@ -25,6 +25,7 @@ import { processLayout } from "@/lib/process-layout";
 import { queryTeamNumbers } from "@/lib/data-query";
 import { fetchTeamComments } from "@/lib/picklist-query";
 import { fetchTeamAutoPaths, setAutoPathDefault } from "@/lib/auto-path-query";
+import { getTeamTbaStats, refreshTbaStats } from "@/lib/tba-cache";
 import { minWidthForDesktop } from "@/lib/constants";
 
 </script>
@@ -67,6 +68,28 @@ import { minWidthForDesktop } from "@/lib/constants";
                             <md-filled-button v-on:click="chooseFiles" disabled v-else>Uploading...</md-filled-button>
                         </div>
                     </div>
+                </div>
+
+                <div class="tba-stats-section">
+                    <div class="tba-stats-header">
+                        <h1>TBA Stats</h1>
+                        <button type="button" class="tba-refresh-button" :disabled="tbaStatsRefreshing"
+                            @click="refreshTbaStatsForTeam">
+                            {{ tbaStatsRefreshing ? 'Refreshing…' : '↻ Refresh TBA Stats' }}
+                        </button>
+                    </div>
+                    <p v-if="tbaStatsError" class="tba-stats-error">{{ tbaStatsError }}</p>
+                    <div v-if="tbaStats" class="tba-stats-grid">
+                        <div v-if="tbaStats.opr != null" class="tba-stat-card">
+                            <div class="stat-label">OPR</div>
+                            <div class="stat-avg">{{ tbaStats.opr.toFixed(1) }}</div>
+                        </div>
+                        <div v-if="tbaStats.dpr != null" class="tba-stat-card">
+                            <div class="stat-label">DPR</div>
+                            <div class="stat-avg">{{ tbaStats.dpr.toFixed(1) }}</div>
+                        </div>
+                    </div>
+                    <p v-else class="no-comments">No TBA stats cached for this event yet — tap Refresh TBA Stats.</p>
                 </div>
 
                 <div v-if="teamLoaded">
@@ -171,7 +194,10 @@ export default {
             autoPathEditId: null,
             autoPathSaveMessage: '',
             autoPathSaveMessageTimeout: null,
-            autoPathColors: ['#ff8c00', '#2f7de1', '#8a3fd1', '#1eae7a', '#d13f6a']
+            autoPathColors: ['#ff8c00', '#2f7de1', '#8a3fd1', '#1eae7a', '#d13f6a'],
+            tbaStats: null,
+            tbaStatsRefreshing: false,
+            tbaStatsError: ''
         }
     },
     methods: {
@@ -196,6 +222,25 @@ export default {
 
             // Load the watchlist (event-wide, not per team).
             this.watchlistStore.loadWatchlist(this.eventStore.eventId);
+
+            // Read cached TBA OPR/DPR (issue #26) — never fetched implicitly,
+            // only via the explicit "Refresh TBA Stats" action below.
+            this.loadTbaStats();
+        },
+        loadTbaStats() {
+            const teamNumber = this.getTeamNumber();
+            this.tbaStats = teamNumber < 0 ? null : getTeamTbaStats(this.eventStore.eventId, teamNumber);
+        },
+        async refreshTbaStatsForTeam() {
+            this.tbaStatsRefreshing = true;
+            this.tbaStatsError = '';
+            try {
+                await refreshTbaStats(this.eventStore.eventId);
+            } catch (e) {
+                this.tbaStatsError = e.message ?? String(e);
+            }
+            this.tbaStatsRefreshing = false;
+            this.loadTbaStats();
         },
         async toggleTeamWatch() {
             if (!this.isUserLead) return;
@@ -382,6 +427,7 @@ export default {
             this.getRobotPhoto();
             this.loadTeamComments();
             this.loadTeamAutoPaths();
+            this.loadTbaStats();
 
             // Keep the URL in sync (issue #46) so this team's page is
             // directly linkable/bookmarkable — replace, not push, so
@@ -549,6 +595,74 @@ export default {
     display: flex;
     justify-content: flex-end;
     margin-bottom: 10px;
+}
+
+.tba-stats-section {
+    margin-top: 24px;
+}
+
+.tba-stats-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.tba-refresh-button {
+    background: none;
+    color: #b05703;
+    border: 1.5px solid #b05703;
+    border-radius: 8px;
+    padding: 7.5px 16px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.tba-refresh-button:hover:not(:disabled) {
+    background: rgba(176, 87, 3, 0.1);
+}
+
+.tba-refresh-button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.tba-stats-error {
+    color: #d32f2f;
+    font-size: 13px;
+}
+
+.tba-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 10px;
+    max-width: 320px;
+}
+
+.tba-stat-card {
+    background: rgba(176, 87, 3, 0.08);
+    border: 1px solid rgba(176, 87, 3, 0.2);
+    border-radius: 10px;
+    padding: 10px 12px;
+    text-align: center;
+}
+
+.tba-stat-card .stat-label {
+    font-size: 11px;
+    color: rgba(128, 128, 128, 0.75);
+    margin-bottom: 4px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.tba-stat-card .stat-avg {
+    font-size: 22px;
+    font-weight: 700;
+    color: #b05703;
+    line-height: 1.1;
 }
 
 .autopath-section {

--- a/supabase/functions/tba-proxy/index.ts
+++ b/supabase/functions/tba-proxy/index.ts
@@ -1,0 +1,151 @@
+// Supabase Edge Function: proxies The Blue Alliance API requests so the TBA
+// API key, and the service-role key needed to write the Match table (which
+// has no INSERT/DELETE policy for authenticated clients — see
+// supabase/database/schemas/prod.sql), never reach the browser (issue #26).
+//
+// Actions (POST body: { action, event_id }):
+//   - get_oprs: any authenticated user. Passes through TBA's
+//     /event/{event_id}/oprs response verbatim (no DB write).
+//   - refresh_schedule: lead/admin only. Ports
+//     util/match_schedule.py's update_match_schedule_for_event — full
+//     delete+insert of the event's Match rows. ScoutAssignment isn't FK'd to
+//     Match (it's keyed by event_id/match_number/alliance/slot_index), so
+//     this doesn't disturb existing scout schedules.
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const TBA_BASE_URL = "https://www.thebluealliance.com/api/v3";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+// Converts a TBA team key like "frc973" to 973, or null for an unfilled/surrogate slot.
+function teamNumberFromKey(teamKey: string | undefined): number | null {
+  if (!teamKey || !teamKey.startsWith("frc")) return null;
+  const n = Number(teamKey.slice(3));
+  return Number.isFinite(n) ? n : null;
+}
+
+function tbaFetch(path: string, apiKey: string) {
+  return fetch(`${TBA_BASE_URL}${path}`, {
+    headers: { "X-TBA-Auth-Key": apiKey },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  const tbaApiKey = Deno.env.get("TBA_API_KEY");
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+  if (!tbaApiKey || !supabaseUrl || !serviceRoleKey) {
+    return jsonResponse({ error: "Server misconfigured: missing TBA/Supabase credentials." }, 500);
+  }
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    return jsonResponse({ error: "Missing Authorization header." }, 401);
+  }
+
+  // Service-role client, scoped to the caller's own JWT purely to identify
+  // who's asking (auth.getUser() validates the token against Supabase Auth).
+  const callerClient = createClient(supabaseUrl, serviceRoleKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
+  const { data: { user }, error: userError } = await callerClient.auth.getUser();
+  if (userError || !user) {
+    return jsonResponse({ error: "Not authenticated." }, 401);
+  }
+
+  let body: { action?: string; event_id?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: "Invalid JSON body." }, 400);
+  }
+
+  const { action, event_id: eventId } = body;
+  if (!eventId || typeof eventId !== "string") {
+    return jsonResponse({ error: "event_id is required." }, 400);
+  }
+
+  const adminClient = createClient(supabaseUrl, serviceRoleKey);
+
+  if (action === "get_oprs") {
+    const response = await tbaFetch(`/event/${eventId}/oprs`, tbaApiKey);
+    if (!response.ok) {
+      return jsonResponse({ error: `TBA request failed: ${response.status}` }, 502);
+    }
+    return jsonResponse(await response.json());
+  }
+
+  if (action === "refresh_schedule") {
+    const { data: userRow, error: roleError } = await adminClient
+      .from("User")
+      .select("role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (roleError || !userRow || (userRow.role !== "lead" && userRow.role !== "admin")) {
+      return jsonResponse({ error: "Only leads and admins can refresh the match schedule." }, 403);
+    }
+
+    const response = await tbaFetch(`/event/${eventId}/matches/simple`, tbaApiKey);
+    if (!response.ok) {
+      return jsonResponse({ error: `TBA request failed: ${response.status}` }, 502);
+    }
+
+    const matches = await response.json();
+    if (!Array.isArray(matches)) {
+      return jsonResponse({ error: "Unexpected TBA response for match schedule." }, 502);
+    }
+
+    const rows = matches.map((match) => {
+      const redTeams = match.alliances?.red?.team_keys ?? [];
+      const blueTeams = match.alliances?.blue?.team_keys ?? [];
+      return {
+        key: match.key,
+        event_id: eventId,
+        comp_level: match.comp_level,
+        set_number: match.set_number,
+        match_number: match.match_number,
+        red1: teamNumberFromKey(redTeams[0]),
+        red2: teamNumberFromKey(redTeams[1]),
+        red3: teamNumberFromKey(redTeams[2]),
+        blue1: teamNumberFromKey(blueTeams[0]),
+        blue2: teamNumberFromKey(blueTeams[1]),
+        blue3: teamNumberFromKey(blueTeams[2]),
+      };
+    });
+
+    // Full replace rather than upsert: TBA regenerates an event's schedule
+    // (e.g. a new playoff bracket after tiebreakers), which can drop matches
+    // that existed under the old schedule.
+    const { error: deleteError } = await adminClient.from("Match").delete().eq("event_id", eventId);
+    if (deleteError) {
+      return jsonResponse({ error: deleteError.message }, 500);
+    }
+
+    if (rows.length > 0) {
+      const { error: insertError } = await adminClient.from("Match").insert(rows);
+      if (insertError) {
+        return jsonResponse({ error: insertError.message }, 500);
+      }
+    }
+
+    return jsonResponse({ matchCount: rows.length });
+  }
+
+  return jsonResponse({ error: `Unknown action: ${action}` }, 400);
+});


### PR DESCRIPTION
Adds a tba-proxy Supabase Edge Function so the TBA API key (and the service-role key needed to write Match rows) never reach the browser. Leads/admins get a "Refresh Event Data" tile on the Account page that re-syncs the match schedule without disturbing existing scout assignments; OPR/DPR is fetched on demand and cached client-side only, then shown in Team Analysis, the Pick List, and Pick'em.


Closes #26 