### PR TITLE
Split Pick List/Pick'em into Scorer/Defender archetypes

### DIFF
--- a/src/components/OfflineQueue.vue
+++ b/src/components/OfflineQueue.vue
@@ -28,6 +28,7 @@ const retryHandlers = {
         return await upsertPersonalPicklist(
             payload.userId as string,
             payload.eventId as string,
+            payload.archetype as 'scorer' | 'defender',
             payload.teamNumbers as number[],
             payload.teamTiers as Record<number, string>
         );
@@ -35,6 +36,7 @@ const retryHandlers = {
     picklist_team: async (payload: Record<string, unknown>) => {
         return await upsertTeamPicklist(
             payload.eventId as string,
+            payload.archetype as 'scorer' | 'defender',
             payload.teamNumbers as number[],
             payload.teamTiers as Record<number, string>
         );

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -26,6 +26,11 @@ export const scoutAssignmentTable = "ScoutAssignment";
 export const pickListTypePersonal = "personal";
 export const pickListTypeTeam = "team";
 
+// Picklist archetypes (issue #27) — a team can be ranked independently
+// under either or both. Defense% threshold only pre-filters Pick'em's
+// Defender candidate pool, it doesn't lock a team into one archetype.
+export const defenseThresholdPercent = 50;
+
 // Auto path alliance / starting side
 export const allianceRed = "red";
 export const allianceBlue = "blue";

--- a/src/lib/picklist-query.ts
+++ b/src/lib/picklist-query.ts
@@ -13,6 +13,15 @@ import {
 } from '@/lib/constants';
 
 /**
+ * A team can be ranked independently under either or both archetypes
+ * (issue #27) — this is a manual per-list distinction, not an automatic
+ * classification.
+ */
+export type Archetype = 'scorer' | 'defender';
+export const ARCHETYPES: Archetype[] = ['scorer', 'defender'];
+export const DEFAULT_ARCHETYPE: Archetype = 'scorer';
+
+/**
  * Fetch all teams attending an event, combined with their robot photo URL.
  * Returns an array of { team_number, name, photo_url | null }.
  */
@@ -71,6 +80,8 @@ export interface TeamMatchSummary {
     diedCount: number;
     beachedCount: number;
     defenseCount: number;
+    /** defenseCount / matches * 100 — used to pre-filter Pick'em's Defender pool (issue #27). */
+    defensePercent: number;
     /** Worst card seen across this team's matches at the event, or null if none. */
     worstCard: 'red' | 'yellow' | null;
 }
@@ -99,7 +110,7 @@ export async function fetchTeamMatchSummaries(eventId: string): Promise<Record<n
         if (teamNumber == null) return;
 
         const summary = summaries[teamNumber] ?? {
-            matches: 0, brokeCount: 0, diedCount: 0, beachedCount: 0, defenseCount: 0, worstCard: null
+            matches: 0, brokeCount: 0, diedCount: 0, beachedCount: 0, defenseCount: 0, defensePercent: 0, worstCard: null
         };
         summary.matches += 1;
         if (row.postmatch_broke) summary.brokeCount += 1;
@@ -110,6 +121,10 @@ export async function fetchTeamMatchSummaries(eventId: string): Promise<Record<n
         else if (row.postmatch_cards === 'yellow' && summary.worstCard !== 'red') summary.worstCard = 'yellow';
 
         summaries[teamNumber] = summary;
+    });
+
+    Object.values(summaries).forEach((summary) => {
+        summary.defensePercent = summary.matches > 0 ? (summary.defenseCount / summary.matches) * 100 : 0;
     });
 
     return summaries;
@@ -259,16 +274,17 @@ export function parseTeamTiers(raw: Record<string, unknown> | null | undefined):
 }
 
 /**
- * Fetch the current user's personal picklist for an event.
+ * Fetch the current user's personal picklist for an event/archetype.
  * Returns the ordered array of team_numbers plus tier assignments, or null if none exists.
  */
-export async function fetchPersonalPicklist(userId: string, eventId: string) {
+export async function fetchPersonalPicklist(userId: string, eventId: string, archetype: Archetype) {
     const { data, error } = await supabase
         .from(pickListTable)
         .select('id, team_numbers, team_tiers, updated_at')
         .eq('user_id', userId)
         .eq('event_id', eventId)
         .eq('type', pickListTypePersonal)
+        .eq('archetype', archetype)
         .limit(1)
         .maybeSingle();
 
@@ -280,15 +296,16 @@ export async function fetchPersonalPicklist(userId: string, eventId: string) {
 }
 
 /**
- * Fetch ALL personal picklists for an event (for the democratic view).
+ * Fetch ALL personal picklists for an event/archetype (for the democratic view).
  * Returns array of { user_id, team_numbers, team_tiers }.
  */
-export async function fetchAllPersonalPicklists(eventId: string) {
+export async function fetchAllPersonalPicklists(eventId: string, archetype: Archetype) {
     const { data, error } = await supabase
         .from(pickListTable)
         .select('user_id, team_numbers, team_tiers')
         .eq('event_id', eventId)
-        .eq('type', pickListTypePersonal);
+        .eq('type', pickListTypePersonal)
+        .eq('archetype', archetype);
 
     if (error) {
         console.error('fetchAllPersonalPicklists error:', error);
@@ -298,16 +315,15 @@ export async function fetchAllPersonalPicklists(eventId: string) {
 }
 
 /**
- * Fetch the team (shared lead) picklist for an event, including the
- * event-wide set of teams that have already been picked (real-world
- * alliance selection), which is only ever stored on this shared row.
+ * Fetch the team (shared lead) picklist for an event/archetype.
  */
-export async function fetchTeamPicklist(eventId: string) {
+export async function fetchTeamPicklist(eventId: string, archetype: Archetype) {
     const { data, error } = await supabase
         .from(pickListTable)
-        .select('id, team_numbers, team_tiers, picked_team_numbers, updated_at')
+        .select('id, team_numbers, team_tiers, updated_at')
         .eq('event_id', eventId)
         .eq('type', pickListTypeTeam)
+        .eq('archetype', archetype)
         .limit(1)
         .maybeSingle();
 
@@ -321,6 +337,9 @@ export async function fetchTeamPicklist(eventId: string) {
 /**
  * Fetch just the event-wide picked-team set. Visible to every user
  * regardless of role, unlike the rest of the team list which is lead-only.
+ * Real-world draft status isn't per-archetype (a team once picked is picked
+ * regardless of role), so this is always anchored to the Scorer archetype's
+ * shared team row rather than being duplicated across both.
  */
 export async function fetchPickedTeams(eventId: string): Promise<number[]> {
     const { data, error } = await supabase
@@ -328,6 +347,7 @@ export async function fetchPickedTeams(eventId: string): Promise<number[]> {
         .select('picked_team_numbers')
         .eq('event_id', eventId)
         .eq('type', pickListTypeTeam)
+        .eq('archetype', DEFAULT_ARCHETYPE)
         .limit(1)
         .maybeSingle();
 
@@ -345,6 +365,7 @@ export async function fetchPickedTeams(eventId: string): Promise<number[]> {
 export async function upsertPersonalPicklist(
     userId: string,
     eventId: string,
+    archetype: Archetype,
     teamNumbers: number[],
     teamTiers: Record<number, Tier>
 ) {
@@ -354,6 +375,7 @@ export async function upsertPersonalPicklist(
         .eq('user_id', userId)
         .eq('event_id', eventId)
         .eq('type', pickListTypePersonal)
+        .eq('archetype', archetype)
         .maybeSingle();
 
     if (fetchError) return fetchError;
@@ -375,6 +397,7 @@ export async function upsertPersonalPicklist(
                 user_id: userId,
                 event_id: eventId,
                 type: pickListTypePersonal,
+                archetype,
                 team_numbers: teamNumbers,
                 team_tiers: teamTiers,
                 updated_at: new Date().toISOString()
@@ -390,6 +413,7 @@ export async function upsertPersonalPicklist(
  */
 export async function upsertTeamPicklist(
     eventId: string,
+    archetype: Archetype,
     teamNumbers: number[],
     teamTiers: Record<number, Tier>
 ) {
@@ -398,6 +422,7 @@ export async function upsertTeamPicklist(
         .select('id')
         .eq('event_id', eventId)
         .eq('type', pickListTypeTeam)
+        .eq('archetype', archetype)
         .maybeSingle();
 
     if (fetchError) return fetchError;
@@ -418,6 +443,7 @@ export async function upsertTeamPicklist(
             .insert({
                 event_id: eventId,
                 type: pickListTypeTeam,
+                archetype,
                 team_numbers: teamNumbers,
                 team_tiers: teamTiers,
                 updated_at: new Date().toISOString()
@@ -427,8 +453,9 @@ export async function upsertTeamPicklist(
 }
 
 /**
- * Update the event-wide picked-team set on the shared team row. This is
- * intentionally separate from upsertTeamPicklist so toggling a checkbox
+ * Update the event-wide picked-team set on the Scorer archetype's shared
+ * team row (see fetchPickedTeams — draft status isn't per-archetype). This
+ * is intentionally separate from upsertTeamPicklist so toggling a checkbox
  * never clobbers a concurrently-edited tier/order draft, and vice versa.
  * Returns the error object or null on success.
  */
@@ -438,6 +465,7 @@ export async function updatePickedTeams(eventId: string, pickedTeamNumbers: numb
         .select('id')
         .eq('event_id', eventId)
         .eq('type', pickListTypeTeam)
+        .eq('archetype', DEFAULT_ARCHETYPE)
         .maybeSingle();
 
     if (fetchError) return fetchError;
@@ -457,6 +485,7 @@ export async function updatePickedTeams(eventId: string, pickedTeamNumbers: numb
             .insert({
                 event_id: eventId,
                 type: pickListTypeTeam,
+                archetype: DEFAULT_ARCHETYPE,
                 picked_team_numbers: pickedTeamNumbers,
                 updated_at: new Date().toISOString()
             });

--- a/src/stores/offline-queue-store.ts
+++ b/src/stores/offline-queue-store.ts
@@ -48,7 +48,7 @@ export const useOfflineQueueStore = defineStore('offlineQueue', {
         enqueue(type: QueueItem['type'], payload: Record<string, unknown>, error?: string) {
             // Deduplicate picklist saves to avoid flooding the queue if offline and autosaving
             if (type === 'picklist_personal') {
-                const existing = this.queue.find(q => q.type === type && q.payload.userId === payload.userId && q.payload.eventId === payload.eventId);
+                const existing = this.queue.find(q => q.type === type && q.payload.userId === payload.userId && q.payload.eventId === payload.eventId && q.payload.archetype === payload.archetype);
                 if (existing) {
                     existing.payload = payload;
                     existing.enqueuedAt = new Date().toISOString();
@@ -57,7 +57,7 @@ export const useOfflineQueueStore = defineStore('offlineQueue', {
                     return;
                 }
             } else if (type === 'picklist_team') {
-                const existing = this.queue.find(q => q.type === type && q.payload.eventId === payload.eventId);
+                const existing = this.queue.find(q => q.type === type && q.payload.eventId === payload.eventId && q.payload.archetype === payload.archetype);
                 if (existing) {
                     existing.payload = payload;
                     existing.enqueuedAt = new Date().toISOString();

--- a/src/stores/picklist-store.ts
+++ b/src/stores/picklist-store.ts
@@ -17,9 +17,13 @@ import {
     fetchTeamMatchSummaries,
     fetchTeamComments,
     TIERS,
-    TIER_GROUPS
+    TIER_GROUPS,
+    ARCHETYPES,
+    DEFAULT_ARCHETYPE
 } from '@/lib/picklist-query';
-import type { Tier, TierGroup, TeamTierStats, TeamMatchSummary } from '@/lib/picklist-query';
+import type { Tier, TierGroup, TeamTierStats, TeamMatchSummary, Archetype } from '@/lib/picklist-query';
+import { defenseThresholdPercent } from '@/lib/constants';
+export type { Archetype };
 
 export type PicklistTab = 'personal' | 'democratic' | 'team';
 
@@ -42,6 +46,13 @@ function emptyTierSections(): Record<TierGroup, number[]> {
     const groups = {} as Record<TierGroup, number[]>;
     TIER_GROUPS.forEach((g) => { groups[g] = []; });
     return groups;
+}
+
+/** One entry per archetype (issue #27), each initialized via the given factory. */
+function perArchetype<T>(factory: () => T): Record<Archetype, T> {
+    const map = {} as Record<Archetype, T>;
+    ARCHETYPES.forEach((a) => { map[a] = factory(); });
+    return map;
 }
 
 /**
@@ -78,27 +89,32 @@ export const usePicklistStore = defineStore('picklist', {
             // Current tab
             activeTab: 'personal' as PicklistTab,
 
+            // Current archetype "super tab" (issue #27) — Scorer vs Defender are
+            // independent rankings, each with their own My/Democratic/Team lists.
+            activeArchetype: DEFAULT_ARCHETYPE as Archetype,
+
             // Teams loaded for the event
             allTeams: [] as TeamEntry[],
             teamsLoaded: false,
 
-            // Personal list — tier-grouped team numbers, source of truth for order + tier
-            personalTierSections: emptyTierSections(),
-            personalListLoaded: false,
+            // Personal list — tier-grouped team numbers per archetype, source of truth for order + tier
+            personalTierSections: perArchetype(emptyTierSections) as Record<Archetype, Record<TierGroup, number[]>>,
+            personalListLoaded: perArchetype(() => false) as Record<Archetype, boolean>,
 
-            // Team (lead) list — tier-grouped team numbers
-            teamTierSections: emptyTierSections(),
-            teamListLoaded: false,
+            // Team (lead) list — tier-grouped team numbers per archetype
+            teamTierSections: perArchetype(emptyTierSections) as Record<Archetype, Record<TierGroup, number[]>>,
+            teamListLoaded: perArchetype(() => false) as Record<Archetype, boolean>,
 
-            // Democratic list — computed (read-only) tier grouping from all personal lists
-            democraticTierSections: emptyTierSections(),
-            democraticListLoaded: false,
+            // Democratic list — computed (read-only) tier grouping from all personal lists, per archetype
+            democraticTierSections: perArchetype(emptyTierSections) as Record<Archetype, Record<TierGroup, number[]>>,
+            democraticListLoaded: perArchetype(() => false) as Record<Archetype, boolean>,
 
-            // Per-team aggregate tier stats across all personal lists
-            teamTierStats: {} as Record<number, TeamTierStats>,
+            // Per-team aggregate tier stats across all personal lists, per archetype
+            teamTierStats: perArchetype(() => ({})) as Record<Archetype, Record<number, TeamTierStats>>,
 
             // Event-wide "has this team already been picked" set, visible to everyone,
-            // editable by leads only. Lives on the shared team-type PickList row.
+            // editable by leads only. Real-world draft status isn't per-archetype (see
+            // picklist-query.ts's fetchPickedTeams), so this stays a single value.
             pickedTeams: [] as number[],
             pickedTeamsLoaded: false,
 
@@ -123,40 +139,45 @@ export const usePicklistStore = defineStore('picklist', {
             return map;
         },
 
-        /** The tier-grouped sections for whichever tab is currently active. */
+        /** The tier-grouped sections for whichever tab/archetype is currently active. */
         activeSections(): Record<TierGroup, number[]> {
-            if (this.activeTab === 'personal') return this.personalTierSections;
-            if (this.activeTab === 'team') return this.teamTierSections;
-            return this.democraticTierSections;
+            if (this.activeTab === 'personal') return this.personalTierSections[this.activeArchetype];
+            if (this.activeTab === 'team') return this.teamTierSections[this.activeArchetype];
+            return this.democraticTierSections[this.activeArchetype];
         },
 
-        personalFlatOrder(): number[] {
-            return TIER_GROUPS.flatMap((g) => this.personalTierSections[g] ?? []);
+        /** Returns a function since callers (e.g. Pick'em) need a specific archetype, not just the active one. */
+        personalFlatOrder(): (archetype: Archetype) => number[] {
+            return (archetype: Archetype) => TIER_GROUPS.flatMap((g) => this.personalTierSections[archetype][g] ?? []);
         },
 
         /** Like personalFlatOrder, but only the actually-ranked tiers (S-DNP) — excludes Unranked. */
-        personalRankedFlatOrder(): number[] {
-            return TIERS.flatMap((g) => this.personalTierSections[g] ?? []);
+        personalRankedFlatOrder(): (archetype: Archetype) => number[] {
+            return (archetype: Archetype) => TIERS.flatMap((g) => this.personalTierSections[archetype][g] ?? []);
         },
 
-        personalTiersMap(): Record<number, Tier> {
-            const map: Record<number, Tier> = {};
-            TIERS.forEach((tier) => {
-                (this.personalTierSections[tier] ?? []).forEach((num) => { map[num] = tier; });
-            });
-            return map;
+        personalTiersMap(): (archetype: Archetype) => Record<number, Tier> {
+            return (archetype: Archetype) => {
+                const map: Record<number, Tier> = {};
+                TIERS.forEach((tier) => {
+                    (this.personalTierSections[archetype][tier] ?? []).forEach((num) => { map[num] = tier; });
+                });
+                return map;
+            };
         },
 
-        teamFlatOrder(): number[] {
-            return TIER_GROUPS.flatMap((g) => this.teamTierSections[g] ?? []);
+        teamFlatOrder(): (archetype: Archetype) => number[] {
+            return (archetype: Archetype) => TIER_GROUPS.flatMap((g) => this.teamTierSections[archetype][g] ?? []);
         },
 
-        teamTiersMap(): Record<number, Tier> {
-            const map: Record<number, Tier> = {};
-            TIERS.forEach((tier) => {
-                (this.teamTierSections[tier] ?? []).forEach((num) => { map[num] = tier; });
-            });
-            return map;
+        teamTiersMap(): (archetype: Archetype) => Record<number, Tier> {
+            return (archetype: Archetype) => {
+                const map: Record<number, Tier> = {};
+                TIERS.forEach((tier) => {
+                    (this.teamTierSections[archetype][tier] ?? []).forEach((num) => { map[num] = tier; });
+                });
+                return map;
+            };
         },
 
         isTeamPicked(): (teamNumber: number) => boolean {
@@ -165,6 +186,12 @@ export const usePicklistStore = defineStore('picklist', {
 
         cardStatusFor(): (teamNumber: number) => 'red' | 'yellow' | null {
             return (teamNumber: number) => this.teamMatchSummaries[teamNumber]?.worstCard ?? null;
+        },
+
+        /** Defense% over the threshold — used to pre-filter Pick'em's Defender candidate pool (issue #27). */
+        isLikelyDefender(): (teamNumber: number) => boolean {
+            return (teamNumber: number) =>
+                (this.teamMatchSummaries[teamNumber]?.defensePercent ?? 0) > defenseThresholdPercent;
         }
     },
     actions: {
@@ -172,14 +199,20 @@ export const usePicklistStore = defineStore('picklist', {
             this.activeTab = tab;
         },
 
+        setArchetype(archetype: Archetype) {
+            this.activeArchetype = archetype;
+        },
+
         async loadAll(eventId: string, userId: string | null, isLead: boolean) {
             await this.loadTeams(eventId);
-            await this.loadPersonalList(userId, eventId);
             await this.loadPickedTeams(eventId);
-            await this.loadDemocraticList(eventId);
             await this.loadTeamMatchSummaries(eventId);
-            if (isLead) {
-                await this.loadTeamList(eventId);
+            for (const archetype of ARCHETYPES) {
+                await this.loadPersonalList(userId, eventId, archetype);
+                await this.loadDemocraticList(eventId, archetype);
+                if (isLead) {
+                    await this.loadTeamList(eventId, archetype);
+                }
             }
         },
 
@@ -193,43 +226,44 @@ export const usePicklistStore = defineStore('picklist', {
             this.teamsLoaded = true;
         },
 
-        async loadPersonalList(userId: string | null, eventId: string) {
-            this.personalListLoaded = false;
+        async loadPersonalList(userId: string | null, eventId: string, archetype: Archetype) {
+            this.personalListLoaded[archetype] = false;
             if (!userId) {
-                this.personalTierSections = buildTierSections([], {}, this.allTeams);
-                this.personalListLoaded = true;
+                this.personalTierSections[archetype] = buildTierSections([], {}, this.allTeams);
+                this.personalListLoaded[archetype] = true;
                 return;
             }
 
-            const result = await fetchPersonalPicklist(userId, eventId);
-            this.personalTierSections = buildTierSections(
+            const result = await fetchPersonalPicklist(userId, eventId, archetype);
+            this.personalTierSections[archetype] = buildTierSections(
                 result?.team_numbers ?? [],
                 parseTeamTiers(result?.team_tiers),
                 this.allTeams
             );
-            this.personalListLoaded = true;
+            this.personalListLoaded[archetype] = true;
         },
 
-        async loadTeamList(eventId: string) {
-            this.teamListLoaded = false;
-            const result = await fetchTeamPicklist(eventId);
-            this.teamTierSections = buildTierSections(
+        async loadTeamList(eventId: string, archetype: Archetype) {
+            this.teamListLoaded[archetype] = false;
+            const result = await fetchTeamPicklist(eventId, archetype);
+            this.teamTierSections[archetype] = buildTierSections(
                 result?.team_numbers ?? [],
                 parseTeamTiers(result?.team_tiers),
                 this.allTeams
             );
-            this.teamListLoaded = true;
+            this.teamListLoaded[archetype] = true;
         },
 
-        async loadDemocraticList(eventId: string) {
-            this.democraticListLoaded = false;
-            const allLists = await fetchAllPersonalPicklists(eventId);
-            this.teamTierStats = computeTeamTierStats(allLists);
-            this.democraticTierSections = computeDemocraticTierGroups(
+        async loadDemocraticList(eventId: string, archetype: Archetype) {
+            this.democraticListLoaded[archetype] = false;
+            const allLists = await fetchAllPersonalPicklists(eventId, archetype);
+            const stats = computeTeamTierStats(allLists);
+            this.teamTierStats[archetype] = stats;
+            this.democraticTierSections[archetype] = computeDemocraticTierGroups(
                 this.allTeams.map((t) => t.team_number),
-                this.teamTierStats
+                stats
             );
-            this.democraticListLoaded = true;
+            this.democraticListLoaded[archetype] = true;
         },
 
         async loadPickedTeams(eventId: string) {
@@ -242,20 +276,20 @@ export const usePicklistStore = defineStore('picklist', {
          * Reset the team list's tiers/order to the current democratic
          * grouping, overwriting whatever is currently staged for the team list.
          */
-        resetTeamListFromDemocratic() {
+        resetTeamListFromDemocratic(archetype: Archetype) {
             const cloned = emptyTierSections();
-            TIER_GROUPS.forEach((g) => { cloned[g] = [...(this.democraticTierSections[g] ?? [])]; });
-            this.teamTierSections = cloned;
+            TIER_GROUPS.forEach((g) => { cloned[g] = [...(this.democraticTierSections[archetype][g] ?? [])]; });
+            this.teamTierSections[archetype] = cloned;
         },
 
         /** Clear the team list's tiers/order entirely. */
-        resetTeamList() {
-            this.teamTierSections = emptyTierSections();
+        resetTeamList(archetype: Archetype) {
+            this.teamTierSections[archetype] = emptyTierSections();
         },
 
         /** Unrank every team on the personal list, back to all-Unranked. */
-        resetPersonalList() {
-            this.personalTierSections = buildTierSections([], {}, this.allTeams);
+        resetPersonalList(archetype: Archetype) {
+            this.personalTierSections[archetype] = buildTierSections([], {}, this.allTeams);
         },
 
         /**
@@ -272,33 +306,33 @@ export const usePicklistStore = defineStore('picklist', {
          * split 3/7/8/10/4 across S/A/B/C/D, everyone else lands in DNP —
          * so every call re-slices the whole ranked order into those fixed
          * buckets rather than splicing into just one tier's array.
-         * flatIndex is always within [0, personalRankedFlatOrder.length]
+         * flatIndex is always within [0, personalRankedFlatOrder(archetype).length]
          * by construction.
          */
-        placeTeamAtFlatIndex(teamNumber: number, flatIndex: number) {
-            const flat = TIERS.flatMap((t) => this.personalTierSections[t]).filter((n) => n !== teamNumber);
+        placeTeamAtFlatIndex(archetype: Archetype, teamNumber: number, flatIndex: number) {
+            const sections = this.personalTierSections[archetype];
+            const flat = TIERS.flatMap((t) => sections[t]).filter((n) => n !== teamNumber);
             flat.splice(flatIndex, 0, teamNumber);
 
             let cursor = 0;
             TIERS.forEach((tier) => {
                 if (tier === 'DNP') {
-                    this.personalTierSections.DNP = flat.slice(cursor);
+                    sections.DNP = flat.slice(cursor);
                 } else {
                     const size = PICKEM_TIER_SIZES[tier];
-                    this.personalTierSections[tier] = flat.slice(cursor, cursor + size);
+                    sections[tier] = flat.slice(cursor, cursor + size);
                     cursor += size;
                 }
             });
 
-            this.personalTierSections.Unranked =
-                this.personalTierSections.Unranked.filter((n) => n !== teamNumber);
+            sections.Unranked = sections.Unranked.filter((n) => n !== teamNumber);
         },
 
-        async savePersonalList(userId: string, eventId: string) {
+        async savePersonalList(userId: string, eventId: string, archetype: Archetype) {
             this.isSaving = true;
             this.lastSaveError = null;
             const error = await upsertPersonalPicklist(
-                userId, eventId, this.personalFlatOrder, this.personalTiersMap
+                userId, eventId, archetype, this.personalFlatOrder(archetype), this.personalTiersMap(archetype)
             );
             this.isSaving = false;
             if (error) {
@@ -310,10 +344,10 @@ export const usePicklistStore = defineStore('picklist', {
             return true;
         },
 
-        async saveTeamList(eventId: string) {
+        async saveTeamList(eventId: string, archetype: Archetype) {
             this.isSaving = true;
             this.lastSaveError = null;
-            const error = await upsertTeamPicklist(eventId, this.teamFlatOrder, this.teamTiersMap);
+            const error = await upsertTeamPicklist(eventId, archetype, this.teamFlatOrder(archetype), this.teamTiersMap(archetype));
             this.isSaving = false;
             if (error) {
                 this.lastSaveError = error.message ?? 'Unknown error';

--- a/src/views/PickEmView.vue
+++ b/src/views/PickEmView.vue
@@ -17,6 +17,12 @@ const queueStore = useOfflineQueueStore();
 const userId = computed(() => authStore.currentUserId);
 const eventId = computed(() => eventStore.eventId);
 
+// Scorer/Defender toggle (issue #27), shared with the Pick List page.
+const activeArchetype = computed({
+    get: () => picklistStore.activeArchetype,
+    set: (v) => picklistStore.setArchetype(v)
+});
+
 const teamsLoaded = ref(false);
 
 // Teams still waiting to be placed, in the order they'll be presented.
@@ -50,23 +56,51 @@ let saveTimer: ReturnType<typeof setTimeout> | null = null;
 
 // ─── Loading ───────────────────────────────────────────────────────────────────
 
+// (Re)builds the placement queue for whichever archetype is currently
+// active — called on initial load and whenever the Scorer/Defender toggle
+// changes, so each archetype gets its own independent placement session.
+// Defender's pool is pre-filtered to likely defenders (defense% over the
+// threshold); Scorer sees every unranked team.
+async function loadArchetypeSession() {
+    await picklistStore.loadPersonalList(userId.value, eventId.value, activeArchetype.value);
+
+    let pool = [...picklistStore.personalTierSections[activeArchetype.value].Unranked];
+    if (activeArchetype.value === 'defender') {
+        pool = pool.filter((teamNumber) => picklistStore.isLikelyDefender(teamNumber));
+    }
+
+    // Shuffle so placement order doesn't always start with the lowest team number.
+    for (let i = pool.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [pool[i], pool[j]] = [pool[j], pool[i]];
+    }
+
+    queue.value = pool;
+    totalToPlace.value = pool.length;
+    placedCount.value = 0;
+    refinementCount.value = 0;
+    phase.value = 'placing';
+    lastRefinementPair = null;
+
+    startNextTeam();
+}
+
 onMounted(async () => {
     await authStore.checkUser();
     await eventStore.updateEvent();
     await picklistStore.loadTeams(eventId.value);
-    await picklistStore.loadPersonalList(userId.value, eventId.value);
+    await picklistStore.loadTeamMatchSummaries(eventId.value);
     teamsLoaded.value = true;
 
-    // Shuffle so placement order doesn't always start with the lowest team number.
-    const shuffled = [...picklistStore.personalTierSections.Unranked];
-    for (let i = shuffled.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-    }
-    queue.value = shuffled;
-    totalToPlace.value = shuffled.length;
+    await loadArchetypeSession();
+});
 
-    startNextTeam();
+// Switching the archetype toggle starts an independent session for the
+// other archetype — flush any pending save first so it isn't lost.
+watch(activeArchetype, async () => {
+    if (!teamsLoaded.value) return;
+    await flushSave();
+    await loadArchetypeSession();
 });
 
 onUnmounted(() => {
@@ -86,15 +120,15 @@ function startNextTeam() {
     // First team ever ranked — nothing to compare against yet. Bootstraps
     // into the middle tier; the very next comparison immediately tests it
     // against something real.
-    if (picklistStore.personalRankedFlatOrder.length === 0) {
-        picklistStore.placeTeamAtFlatIndex(candidate.value, 0);
+    if (picklistStore.personalRankedFlatOrder(activeArchetype.value).length === 0) {
+        picklistStore.placeTeamAtFlatIndex(activeArchetype.value, candidate.value, 0);
         placedCount.value++;
         scheduleSave();
         startNextTeam();
         return;
     }
 
-    sortedSnapshot.value = [...picklistStore.personalRankedFlatOrder];
+    sortedSnapshot.value = [...picklistStore.personalRankedFlatOrder(activeArchetype.value)];
     lo.value = 0;
     hi.value = sortedSnapshot.value.length;
     presentNextComparison();
@@ -131,7 +165,7 @@ function chooseTeam(winner: number) {
 }
 
 function finalizePlacement() {
-    picklistStore.placeTeamAtFlatIndex(candidate.value, lo.value);
+    picklistStore.placeTeamAtFlatIndex(activeArchetype.value, candidate.value, lo.value);
     placedCount.value++;
     scheduleSave();
     startNextTeam();
@@ -140,7 +174,7 @@ function finalizePlacement() {
 // ─── Continuous refinement ────────────────────────────────────────────────────
 
 function enterRefinementMode() {
-    if (picklistStore.personalRankedFlatOrder.length < 2) {
+    if (picklistStore.personalRankedFlatOrder(activeArchetype.value).length < 2) {
         phase.value = 'insufficient';
         candidate.value = null;
         compareAgainst.value = null;
@@ -159,7 +193,7 @@ function enterRefinementMode() {
 const REFINEMENT_WINDOW = 5;
 
 function presentRefinementPair() {
-    const flat = picklistStore.personalRankedFlatOrder;
+    const flat = picklistStore.personalRankedFlatOrder(activeArchetype.value);
     const n = flat.length;
     const anchor = Math.floor(Math.random() * n);
     const maxWindow = Math.min(REFINEMENT_WINDOW, n - 1);
@@ -190,7 +224,7 @@ function presentRefinementPair() {
 function chooseRefinementTeam(winner: number) {
     if (winner === compareAgainst.value) {
         // The lower-ranked team was actually preferred — swap it up.
-        picklistStore.placeTeamAtFlatIndex(winner, refinementUpperIndex);
+        picklistStore.placeTeamAtFlatIndex(activeArchetype.value, winner, refinementUpperIndex);
         scheduleSave();
     }
     refinementCount.value++;
@@ -206,8 +240,14 @@ function pickWinner(winner: number) {
 }
 
 // ─── Saving ─────────────────────────────────────────────────────────────────────
+// Which archetype a scheduled save applies to, captured at schedule time —
+// NOT re-read from activeArchetype at flush time, since the archetype
+// toggle explicitly flushes before switching (see the watcher above) and by
+// then activeArchetype has already moved on to the new value.
+let pendingSaveArchetype: 'scorer' | 'defender' | null = null;
 
 function scheduleSave() {
+    pendingSaveArchetype = activeArchetype.value;
     if (saveTimer) clearTimeout(saveTimer);
     saveTimer = setTimeout(flushSave, 800);
 }
@@ -217,15 +257,18 @@ async function flushSave() {
         clearTimeout(saveTimer);
         saveTimer = null;
     }
-    if (!userId.value) return;
+    if (!userId.value || pendingSaveArchetype == null) return;
 
-    const success = await picklistStore.savePersonalList(userId.value, eventId.value);
+    const archetype = pendingSaveArchetype;
+    pendingSaveArchetype = null;
+    const success = await picklistStore.savePersonalList(userId.value, eventId.value, archetype);
     if (!success) {
         queueStore.enqueue('picklist_personal', {
             userId: userId.value,
             eventId: eventId.value,
-            teamNumbers: picklistStore.personalFlatOrder,
-            teamTiers: picklistStore.personalTiersMap
+            archetype,
+            teamNumbers: picklistStore.personalFlatOrder(archetype),
+            teamTiers: picklistStore.personalTiersMap(archetype)
         }, picklistStore.lastSaveError ?? undefined);
     }
 }
@@ -282,6 +325,20 @@ const infoModalTeamNumber = computed(() => infoModalSide.value === 'candidate' ?
     <div class="main-content">
         <h1>Pick'em</h1>
         <p class="pickem-subtitle">Pick the team you'd rather have — we'll slot it into your Pick List for you.</p>
+
+        <!-- Archetype toggle (issue #27) — shared with the Pick List's super tabs -->
+        <div class="pickem-archetype-tabs" role="tablist">
+            <button id="pickem-archetype-scorer" class="pickem-archetype-tab"
+                :class="{ 'pickem-archetype-tab--active': activeArchetype === 'scorer' }" role="tab"
+                :aria-selected="activeArchetype === 'scorer'" @click="activeArchetype = 'scorer'">
+                Scorer
+            </button>
+            <button id="pickem-archetype-defender" class="pickem-archetype-tab"
+                :class="{ 'pickem-archetype-tab--active': activeArchetype === 'defender' }" role="tab"
+                :aria-selected="activeArchetype === 'defender'" @click="activeArchetype = 'defender'">
+                Defender
+            </button>
+        </div>
 
         <div v-if="!teamsLoaded" class="data-tile pickem-status">Loading teams…</div>
 
@@ -402,6 +459,34 @@ const infoModalTeamNumber = computed(() => infoModalSide.value === 'candidate' ?
     color: rgba(128, 128, 128, 0.9);
     margin-top: -8px;
     margin-bottom: 20px;
+}
+
+.pickem-archetype-tabs {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 20px;
+}
+
+.pickem-archetype-tab {
+    background: rgba(128, 128, 128, 0.1);
+    border: 1.5px solid transparent;
+    border-radius: 20px;
+    padding: 7px 18px;
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--primary-text-color);
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.pickem-archetype-tab:hover {
+    border-color: rgba(176, 87, 3, 0.4);
+}
+
+.pickem-archetype-tab--active {
+    background: #b05703;
+    border-color: #b05703;
+    color: #fff;
 }
 
 .pickem-status {

--- a/src/views/PicklistView.vue
+++ b/src/views/PicklistView.vue
@@ -115,6 +115,13 @@ const activeTab = computed({
     set: (v) => picklistStore.setTab(v)
 });
 
+// Scorer/Defender "super tab" (issue #27) — an independent ranking axis
+// alongside My/Democratic/Team List.
+const activeArchetype = computed({
+    get: () => picklistStore.activeArchetype,
+    set: (v) => picklistStore.setArchetype(v)
+});
+
 const isEditable = computed(() =>
     (activeTab.value === 'personal') ||
     (activeTab.value === 'team' && isLead.value)
@@ -130,7 +137,7 @@ const showVoteStats = computed(() => activeTab.value !== 'personal');
 // aggregate.
 const showPickedCheckbox = computed(() => activeTab.value === 'team');
 
-const hasDemocraticVotes = computed(() => Object.keys(picklistStore.teamTierStats).length > 0);
+const hasDemocraticVotes = computed(() => Object.keys(picklistStore.teamTierStats[activeArchetype.value]).length > 0);
 
 // ─── Loading ───────────────────────────────────────────────────────────────────
 
@@ -178,23 +185,25 @@ async function saveList() {
     let success = false;
 
     if (activeTab.value === 'personal' && userId.value) {
-        success = await picklistStore.savePersonalList(userId.value, eventId.value);
+        success = await picklistStore.savePersonalList(userId.value, eventId.value, activeArchetype.value);
         if (!success) {
             // Enqueue for later
             queueStore.enqueue('picklist_personal', {
                 userId: userId.value,
                 eventId: eventId.value,
-                teamNumbers: picklistStore.personalFlatOrder,
-                teamTiers: picklistStore.personalTiersMap
+                archetype: activeArchetype.value,
+                teamNumbers: picklistStore.personalFlatOrder(activeArchetype.value),
+                teamTiers: picklistStore.personalTiersMap(activeArchetype.value)
             }, picklistStore.lastSaveError ?? undefined);
         }
     } else if (activeTab.value === 'team' && isLead.value) {
-        success = await picklistStore.saveTeamList(eventId.value);
+        success = await picklistStore.saveTeamList(eventId.value, activeArchetype.value);
         if (!success) {
             queueStore.enqueue('picklist_team', {
                 eventId: eventId.value,
-                teamNumbers: picklistStore.teamFlatOrder,
-                teamTiers: picklistStore.teamTiersMap
+                archetype: activeArchetype.value,
+                teamNumbers: picklistStore.teamFlatOrder(activeArchetype.value),
+                teamTiers: picklistStore.teamTiersMap(activeArchetype.value)
             }, picklistStore.lastSaveError ?? undefined);
         }
     }
@@ -205,7 +214,7 @@ async function saveList() {
 const isRefreshingDemocratic = ref(false);
 async function refreshDemocratic() {
     isRefreshingDemocratic.value = true;
-    await picklistStore.loadDemocraticList(eventId.value);
+    await picklistStore.loadDemocraticList(eventId.value, activeArchetype.value);
     isRefreshingDemocratic.value = false;
 }
 
@@ -229,7 +238,7 @@ async function refreshTbaStatsForEvent() {
 // ─── Reset Team List from Democratic ──────────────────────────────────────────
 
 async function resetTeamFromDemocratic() {
-    picklistStore.resetTeamListFromDemocratic();
+    picklistStore.resetTeamListFromDemocratic(activeArchetype.value);
     await saveList();
 }
 
@@ -237,7 +246,7 @@ async function resetTeamFromDemocratic() {
 
 const confirmingTeamReset = ref(false);
 async function resetTeamListEmpty() {
-    picklistStore.resetTeamList();
+    picklistStore.resetTeamList(activeArchetype.value);
     confirmingTeamReset.value = false;
     await saveList();
 }
@@ -246,7 +255,7 @@ async function resetTeamListEmpty() {
 
 const confirmingPersonalReset = ref(false);
 async function resetPersonalListEmpty() {
-    picklistStore.resetPersonalList();
+    picklistStore.resetPersonalList(activeArchetype.value);
     confirmingPersonalReset.value = false;
     await saveList();
 }
@@ -257,7 +266,7 @@ function exportTeamListCsv() {
     const rows: Record<string, unknown>[] = [];
     let rank = 0;
     TIER_GROUPS.forEach((group) => {
-        (picklistStore.teamTierSections[group] ?? []).forEach((teamNumber) => {
+        (picklistStore.teamTierSections[activeArchetype.value][group] ?? []).forEach((teamNumber) => {
             const team = picklistStore.teamMap[teamNumber];
             if (!team) return;
             rank += 1;
@@ -277,7 +286,7 @@ function exportTeamListCsv() {
 
     const link = document.createElement('a');
     link.href = url;
-    link.download = `team-picklist-${eventId.value}.csv`;
+    link.download = `team-picklist-${eventId.value}-${activeArchetype.value}.csv`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -287,7 +296,7 @@ function exportTeamListCsv() {
 // ─── Tier stats (Democratic / Team tabs) ──────────────────────────────────────
 
 function tierStatsFor(teamNumber: number) {
-    return picklistStore.teamTierStats[teamNumber] ?? null;
+    return picklistStore.teamTierStats[activeArchetype.value][teamNumber] ?? null;
 }
 
 function tierGroupLabel(group: string) {
@@ -344,6 +353,20 @@ function toggleTierCollapse(group: string) {
                 </button>
             </div>
             <p v-if="tbaStatsError" class="picklist-tba-error">{{ tbaStatsError }}</p>
+
+            <!-- Archetype super tabs (issue #27) — Scorer/Defender are independent rankings -->
+            <div class="picklist-archetype-tabs" role="tablist">
+                <button id="archetype-scorer" class="picklist-archetype-tab"
+                    :class="{ 'picklist-archetype-tab--active': activeArchetype === 'scorer' }" role="tab"
+                    :aria-selected="activeArchetype === 'scorer'" @click="activeArchetype = 'scorer'">
+                    Scorer
+                </button>
+                <button id="archetype-defender" class="picklist-archetype-tab"
+                    :class="{ 'picklist-archetype-tab--active': activeArchetype === 'defender' }" role="tab"
+                    :aria-selected="activeArchetype === 'defender'" @click="activeArchetype = 'defender'">
+                    Defender
+                </button>
+            </div>
 
             <!-- Tab bar -->
             <div class="picklist-tabs" role="tablist">
@@ -604,6 +627,34 @@ function toggleTierCollapse(group: string) {
 }
 
 /* ── Tabs ── */
+.picklist-archetype-tabs {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 14px;
+}
+
+.picklist-archetype-tab {
+    background: rgba(128, 128, 128, 0.1);
+    border: 1.5px solid transparent;
+    border-radius: 20px;
+    padding: 7px 18px;
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--primary-text-color);
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.picklist-archetype-tab:hover {
+    border-color: rgba(176, 87, 3, 0.4);
+}
+
+.picklist-archetype-tab--active {
+    background: #b05703;
+    border-color: #b05703;
+    color: #fff;
+}
+
 .picklist-tabs {
     display: flex;
     gap: 4px;

--- a/supabase/database/schemas/prod.sql
+++ b/supabase/database/schemas/prod.sql
@@ -344,7 +344,9 @@ CREATE TABLE IF NOT EXISTS "public"."PickList" (
     "updated_at" timestamp with time zone DEFAULT "now"(),
     "team_tiers" jsonb DEFAULT '{}'::jsonb NOT NULL,
     "picked_team_numbers" integer[] DEFAULT '{}'::integer[] NOT NULL,
-    CONSTRAINT "PickList_type_check" CHECK (("type" = ANY (ARRAY['personal'::"text", 'team'::"text"])))
+    "archetype" "text" DEFAULT 'scorer'::"text" NOT NULL,
+    CONSTRAINT "PickList_type_check" CHECK (("type" = ANY (ARRAY['personal'::"text", 'team'::"text"]))),
+    CONSTRAINT "PickList_archetype_check" CHECK (("archetype" = ANY (ARRAY['scorer'::"text", 'defender'::"text"])))
 );
 
 
@@ -517,11 +519,11 @@ CREATE UNIQUE INDEX "strategyboard_match_unique" ON "public"."StrategyBoard" USI
 
 
 
-CREATE UNIQUE INDEX "picklist_personal_unique" ON "public"."PickList" USING "btree" ("user_id", "event_id", "type") WHERE ("type" = 'personal'::"text");
+CREATE UNIQUE INDEX "picklist_personal_unique" ON "public"."PickList" USING "btree" ("user_id", "event_id", "type", "archetype") WHERE ("type" = 'personal'::"text");
 
 
 
-CREATE UNIQUE INDEX "picklist_team_unique" ON "public"."PickList" USING "btree" ("event_id", "type") WHERE ("type" = 'team'::"text");
+CREATE UNIQUE INDEX "picklist_team_unique" ON "public"."PickList" USING "btree" ("event_id", "type", "archetype") WHERE ("type" = 'team'::"text");
 
 
 

--- a/supabase/migrations/20260831120000_add_picklist_archetype.sql
+++ b/supabase/migrations/20260831120000_add_picklist_archetype.sql
@@ -1,0 +1,10 @@
+-- Split picklists into independent Scorer/Defender archetypes (issue #27).
+-- Existing rows default to 'scorer', so today's lists become the Scorer
+-- lists automatically.
+ALTER TABLE "public"."PickList" ADD COLUMN "archetype" text NOT NULL DEFAULT 'scorer';
+ALTER TABLE "public"."PickList" ADD CONSTRAINT "PickList_archetype_check" CHECK (("archetype" = ANY (ARRAY['scorer'::"text", 'defender'::"text"])));
+
+DROP INDEX "picklist_personal_unique";
+DROP INDEX "picklist_team_unique";
+CREATE UNIQUE INDEX "picklist_personal_unique" ON "public"."PickList" USING "btree" ("user_id", "event_id", "type", "archetype") WHERE ("type" = 'personal'::"text");
+CREATE UNIQUE INDEX "picklist_team_unique" ON "public"."PickList" USING "btree" ("event_id", "type", "archetype") WHERE ("type" = 'team'::"text");


### PR DESCRIPTION
Adds an archetype column to PickList so My/Democratic/Team lists can be ranked independently per role, surfaced as super tabs above the existing tab bar. Pick'em gets a matching toggle; its Defender queue is pre-filtered to teams whose scouted defense% clears a threshold, so comparisons only involve plausible defenders. Existing lists default to archetype='scorer', preserving all prior rankings.


Closes #27 