### PR TITLE
Let leads edit scout submissions from Data Status

### DIFF
--- a/src/components/PitScoutingSection.vue
+++ b/src/components/PitScoutingSection.vue
@@ -125,6 +125,13 @@ export default {
         teamNumber: {
             type: Number,
             required: true
+        },
+        // Auto-opens the edit form for this team's newest pit submission
+        // once loaded — used by Data Status's lead-only edit shortcut
+        // (issue #31).
+        autoEdit: {
+            type: Boolean,
+            default: false
         }
     },
     data() {
@@ -150,6 +157,10 @@ export default {
             this.teamPitDataLoaded = false;
             this.teamPitData = await fetchTeamPitData(this.teamNumber, this.eventStore.eventId);
             this.teamPitDataLoaded = true;
+
+            if (this.autoEdit && this.teamPitData.length > 0 && this.isUserWriteAccess) {
+                this.startEditPit(this.teamPitData[0].id);
+            }
         },
         startAddPit() {
             this.pitFormMode = 'add';
@@ -160,10 +171,21 @@ export default {
             this.pitFormEditId = id;
         },
         onPitFormCancel() {
+            // Reached via Data Status's edit shortcut (issue #31) — cancelling
+            // returns there rather than falling back to this team's view mode.
+            if (this.autoEdit) {
+                this.$router.push('/data-status');
+                return;
+            }
             this.pitFormMode = 'view';
             this.pitFormEditId = null;
         },
         async onPitFormSaved({ queuedOffline }: { queuedOffline: boolean }) {
+            if (this.autoEdit) {
+                this.$router.push('/data-status');
+                return;
+            }
+
             this.pitFormMode = 'view';
             this.pitFormEditId = null;
 

--- a/src/lib/2026/match-scouting-form.ts
+++ b/src/lib/2026/match-scouting-form.ts
@@ -145,10 +145,33 @@ export function getMatchPostmatchFields() {
     ];
 }
 
+// Pre-fills a team-row schema's component values from an existing MatchData
+// row (issue #31 — editing an existing submission), keyed the same way
+// parseScoutData() writes them: `${section.key}_${component.key}`. Mirrors
+// pit-scouting-form.ts's applyExistingPitData, adapted for match data's
+// per-section column prefixes instead of pit's flat `pit_` prefix.
+function applyExistingMatchTeamData(schema, row) {
+    schema.forEach((section) => {
+        section.components.forEach((component) => {
+            const dbKey = `${section.key}_${component.key}`.toLowerCase();
+            if (!(dbKey in row) || row[dbKey] == null) return;
+
+            const raw = row[dbKey];
+            if (component.type === "dropdown") {
+                const idx = component.options.choices.findIndex((c) => c.key === raw);
+                if (idx >= 0) component.value = idx;
+            } else {
+                component.value = raw;
+            }
+        });
+    });
+}
+
 // The full {key, name, components} section shape for one team's row —
 // matches what FormSection/validateForm/parseScoutData already expect.
-export function buildTeamRowSchema() {
-    return [
+// Pass existingData (a raw MatchData row) to pre-fill for editing.
+export function buildTeamRowSchema({ existingData = null } = {}) {
+    const schema = [
         {
             key: "prematch",
             name: "Pre-match",
@@ -165,4 +188,10 @@ export function buildTeamRowSchema() {
             components: getMatchPostmatchFields()
         }
     ];
+
+    if (existingData) {
+        applyExistingMatchTeamData(schema, existingData);
+    }
+
+    return schema;
 }

--- a/src/lib/data-query.ts
+++ b/src/lib/data-query.ts
@@ -96,7 +96,7 @@ export async function queryAllEvents() {
 }
 
 export async function queryEventPitData(eventId) {
-    const { data, error } = await supabase.from(pitScoutTable).select('pit_team_number, created_at').eq('event', eventId);
+    const { data, error } = await supabase.from(pitScoutTable).select('id, pit_team_number, created_at').eq('event', eventId);
 
     if (error) {
         console.log(error);

--- a/src/lib/picklist-query.ts
+++ b/src/lib/picklist-query.ts
@@ -200,6 +200,25 @@ export async function fetchPitDataById(id: number) {
 }
 
 /**
+ * Fetch a single raw MatchData row by id (native prematch_/auto_/postmatch_
+ * column names), used to pre-fill the match scouting edit form (issue #31).
+ */
+export async function fetchMatchDataById(id: number) {
+    const { data, error } = await supabase
+        .from(matchScoutTable)
+        .select('*')
+        .eq('id', id)
+        .single();
+
+    if (error) {
+        console.error('fetchMatchDataById error:', error);
+        return null;
+    }
+
+    return data;
+}
+
+/**
  * Fetch match- and pit-scouting comments for a team, attributed to their author.
  * Returns array of { source, author, comment, match_number, created_at }, newest first.
  */

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -6,6 +6,7 @@ import { isSiteReadPrivate, isSiteWritePrivate } from "@/lib/constants";
 import { createRouter, createWebHistory } from "vue-router";
 import DataUploadView from "@/views/DataUploadView.vue";
 import MatchScoutView from "@/views/MatchScoutView.vue";
+import MatchDataEditView from "@/views/MatchDataEditView.vue";
 import PitScoutingView from "@/views/PitScoutingView.vue";
 import TeamAnalysisView from "@/views/TeamAnalysisView.vue";
 import EventAnalysisView from "@/views/EventAnalysisView.vue";
@@ -52,6 +53,17 @@ const router = createRouter({
       meta: {
         requiresAuth: isSiteReadPrivate,
         minRole: 'member'
+      }
+    },
+    {
+      // Edit an existing match-scouting submission (issue #31) — reached
+      // from Data Status, lead/admin only.
+      path: "/match/edit/:id",
+      name: "Edit Match Data | GreyScout",
+      component: MatchDataEditView,
+      meta: {
+        requiresAuth: isSiteReadPrivate,
+        minRole: 'lead'
       }
     },
     {

--- a/src/views/DataStatusView.vue
+++ b/src/views/DataStatusView.vue
@@ -5,6 +5,7 @@ import { RouterLink } from 'vue-router';
 import CollapsibleSection from "@/components/CollapsibleSection.vue";
 
 import { useEventStore } from "@/stores/event-store";
+import { useAuthStore } from "@/stores/auth-store";
 import { queryEventMatchSchedule, queryEventData, queryEventPitData, queryTeamNumbers } from "@/lib/data-query";
 import { matchNumberColumn, teamNumberColumn } from "@/lib/constants";
 </script>
@@ -30,14 +31,16 @@ import { matchNumberColumn, teamNumberColumn } from "@/lib/constants";
                 <p v-if="teams.length === 0">No teams loaded for this event yet.</p>
 
                 <div v-else class="pit-status-grid">
-                    <RouterLink v-for="team in teams" :key="team.team_number" :to="`/team/${team.team_number}`"
-                        class="pit-status-cell"
+                    <div v-for="team in teams" :key="team.team_number" class="pit-status-cell"
                         :class="pitScoutedTeams[team.team_number] ? 'cell-scouted' : 'cell-missing'">
-                        <span class="status-dot"
-                            :class="pitScoutedTeams[team.team_number] ? 'status-scouted' : 'status-missing'"></span>
-                        {{ team.team_number }}
-                        <span class="team-name">- {{ team.name }}</span>
-                    </RouterLink>
+                        <RouterLink :to="`/team/${team.team_number}`" class="pit-status-link">
+                            <span class="status-dot"
+                                :class="pitScoutedTeams[team.team_number] ? 'status-scouted' : 'status-missing'"></span>
+                            {{ team.team_number }}
+                        </RouterLink>
+                        <button v-if="isLead && pitScoutedTeams[team.team_number]" type="button" class="edit-pencil"
+                            title="Edit pit scouting submission" @click="goToPitEdit(team.team_number)">✎</button>
+                    </div>
                 </div>
             </CollapsibleSection>
 
@@ -71,13 +74,14 @@ import { matchNumberColumn, teamNumberColumn } from "@/lib/constants";
                             <tr v-for="match in qualMatches" :key="match.key">
                                 <td>Q{{ match.match_number }}</td>
                                 <td v-for="slotKey in slotKeys" :key="slotKey" :class="cellClass(match, slotKey)">
-                                    <RouterLink v-if="match[slotKey]" :to="`/team/${match[slotKey]}`" class="team-link">
-                                        <span class="status-dot" :class="statusDotClass(match.match_number, match[slotKey])"></span>
-                                        {{ match[slotKey] }}
-                                        <span class="team-name" v-if="teamNameByNumber[match[slotKey]]">
-                                            - {{ teamNameByNumber[match[slotKey]] }}
-                                        </span>
-                                    </RouterLink>
+                                    <template v-if="match[slotKey]">
+                                        <RouterLink :to="`/team/${match[slotKey]}`" class="team-link">
+                                            <span class="status-dot" :class="statusDotClass(match.match_number, match[slotKey])"></span>
+                                            {{ match[slotKey] }}
+                                        </RouterLink>
+                                        <button v-if="isLead && scoutedEntryFor(match, slotKey)" type="button" class="edit-pencil"
+                                            title="Edit match submission" @click="goToMatchEdit(match, slotKey)">✎</button>
+                                    </template>
                                 </td>
                             </tr>
                         </tbody>
@@ -96,18 +100,21 @@ export default {
     data() {
         return {
             eventStore: null,
+            authStore: null,
             loaded: false,
             schedule: [],
             teams: [],
-            teamNameByNumber: {},
-            // `${match_number}|${team_number}` -> { count, noShow }
+            // `${match_number}|${team_number}` -> { count, noShow, id }
             scoutedByKey: {},
-            // team_number -> true
+            // team_number -> { id }
             pitScoutedTeams: {},
             slotKeys: SLOT_KEYS
         }
     },
     computed: {
+        isLead() {
+            return this.authStore?.isLead ?? false;
+        },
         qualMatches() {
             return this.schedule.filter(m => m.comp_level === 'qm');
         },
@@ -152,24 +159,29 @@ export default {
 
             this.teams = [...teams].sort((a, b) => a.team_number - b.team_number);
 
-            this.teamNameByNumber = {};
-            teams.forEach((team) => {
-                this.teamNameByNumber[team.team_number] = team.name;
-            });
-
             this.scoutedByKey = {};
             matchData.forEach((row) => {
                 const key = `${row[matchNumberColumn]}|${row[teamNumberColumn]}`;
                 if (!this.scoutedByKey[key]) {
-                    this.scoutedByKey[key] = { count: 0, noShow: false };
+                    this.scoutedByKey[key] = { count: 0, noShow: false, id: row.id, createdAt: row.created_at };
                 }
-                this.scoutedByKey[key].count += 1;
-                this.scoutedByKey[key].noShow = this.scoutedByKey[key].noShow || !!row.prematch_noshow;
+                const entry = this.scoutedByKey[key];
+                entry.count += 1;
+                entry.noShow = entry.noShow || !!row.prematch_noshow;
+                // If a slot somehow has more than one submission, edit links
+                // should point at the most recent one.
+                if (row.created_at > entry.createdAt) {
+                    entry.id = row.id;
+                    entry.createdAt = row.created_at;
+                }
             });
 
             this.pitScoutedTeams = {};
             pitData.forEach((row) => {
-                this.pitScoutedTeams[row.pit_team_number] = true;
+                const existing = this.pitScoutedTeams[row.pit_team_number];
+                if (!existing || row.created_at > existing.createdAt) {
+                    this.pitScoutedTeams[row.pit_team_number] = { id: row.id, createdAt: row.created_at };
+                }
             });
 
             this.loaded = true;
@@ -187,10 +199,32 @@ export default {
             const alliance = slotKey.startsWith('red') ? 'red-cell' : 'blue-cell';
             if (!teamNumber) return [alliance];
             return [alliance, `cell-${this.statusFor(match.match_number, teamNumber)}`];
+        },
+        // Leads/admins clicking an already-scouted slot go straight to
+        // editing that submission (issue #31); everyone else, and unscouted
+        // slots, keep the original team-analysis link.
+        // The scouted submission entry (with its row id) for a match slot,
+        // or undefined if that slot hasn't been scouted — used to decide
+        // whether the lead-only edit pencil shows, and where it goes.
+        scoutedEntryFor(match, slotKey) {
+            return this.scoutedByKey[`${match.match_number}|${match[slotKey]}`];
+        },
+        // Edit pencil handlers (issue #31) — separate from the team link
+        // itself, which always goes to Team Analysis.
+        goToMatchEdit(match, slotKey) {
+            const entry = this.scoutedEntryFor(match, slotKey);
+            if (entry) this.$router.push(`/match/edit/${entry.id}`);
+        },
+        // Pit scouting reuses the existing Pit Scouting page (auto-opened to
+        // this team, in edit mode) rather than a dedicated page.
+        goToPitEdit(teamNumber) {
+            this.$router.push(`/pit?team=${teamNumber}&editPit=1`);
         }
     },
     created() {
         this.eventStore = useEventStore();
+        this.authStore = useAuthStore();
+        this.authStore.checkUser();
         this.loadData();
     }
 }
@@ -266,23 +300,49 @@ export default {
     max-width: 100%;
 }
 
-.team-name {
-    opacity: 0.75;
-}
-
 /* Both the pit-status-grid cells and the match-table team cells are now
    RouterLinks (issue #46) — undo the browser's default link styling so
    they still read as plain status cells, not blue underlined text. */
-.pit-status-cell,
+.pit-status-link,
 .team-link {
     color: inherit;
     text-decoration: none;
     cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
 }
 
-.pit-status-cell:hover,
+.pit-status-link:hover,
 .team-link:hover {
     text-decoration: underline;
+}
+
+/* Leads/admins edit shortcut (issue #31) — a separate button next to the
+   team link, rather than repurposing the link itself, so clicking the link
+   always goes to Team Analysis. */
+.edit-pencil {
+    background: none;
+    border: none;
+    margin-left: 4px;
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+    color: rgba(128, 128, 128, 0.7);
+    border-radius: 6px;
+    flex-shrink: 0;
+    /* A proper touch target (roughly 44x44, the standard minimum tap size)
+       so the pencil is easy to hit with a finger, not just a mouse. */
+    min-width: 44px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.edit-pencil:hover {
+    color: #b05703;
+    background: rgba(176, 87, 3, 0.12);
 }
 
 .red-header {
@@ -295,7 +355,9 @@ export default {
 
 .pit-status-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    /* Cells only show the team number now (no name), so a narrower min width
+       fits more per row than when this had to fit "9999 - Team Name". */
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
     gap: 8px;
     width: 100%;
 }
@@ -307,6 +369,11 @@ export default {
     padding: 8px 10px;
     border-radius: 8px;
     font-size: 0.9em;
+}
+
+.pit-status-link {
+    flex: 1;
+    min-width: 0;
 }
 
 .pit-status-cell.cell-scouted {

--- a/src/views/MatchDataEditView.vue
+++ b/src/views/MatchDataEditView.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+// @ts-nocheck
+import { RouterLink } from 'vue-router';
+import FormSection from "@/components/FormSection.vue";
+
+import { matchScoutTable } from "@/lib/constants";
+import { buildTeamRowSchema } from "@/lib/2026/match-scouting-form";
+import { validateForm, parseScoutData, updateScoutData } from "@/lib/data-submission";
+import { fetchMatchDataById } from "@/lib/picklist-query";
+import { useOfflineQueueStore } from "@/stores/offline-queue-store";
+
+import "@material/web/button/filled-button";
+</script>
+
+<template>
+    <div class="main-content">
+        <h1>Edit Match Submission</h1>
+
+        <div v-if="!loaded" class="data-tile">Loading…</div>
+
+        <div v-else-if="!matchRow" class="data-tile error-tile">
+            <h1>Submission not found.</h1>
+            <RouterLink to="/data-status" class="back-link">‹ Back to Data Status</RouterLink>
+        </div>
+
+        <template v-else>
+            <div class="data-tile match-context">
+                Match {{ matchRow.prematch_match_number }} — Team {{ matchRow.prematch_team_number }}
+                ({{ matchRow.prematch_alliance }})
+            </div>
+
+            <form>
+                <FormSection v-for="section in visibleSections" :key="section.key" :section-key="section.key"
+                    :name="section.name" :components="section.components" :color="colorFor(section.key)"
+                    @form-update="formValidation">
+                </FormSection>
+            </form>
+
+            <div class="data-tile error-tile" v-if="formInvalid">
+                <h1>^^^ Form is invalid. Please check the form for errors ^^^</h1>
+            </div>
+
+            <div class="button-container" v-if="!isSaving">
+                <RouterLink to="/data-status">
+                    <md-filled-button class="cancel-button">CANCEL</md-filled-button>
+                </RouterLink>
+                <md-filled-button v-on:click="save" class="save-button">SAVE</md-filled-button>
+            </div>
+        </template>
+    </div>
+</template>
+
+<script lang="ts">
+export default {
+    data() {
+        return {
+            queueStore: null,
+            loaded: false,
+            matchRow: null,
+            schema: [],
+            formInvalid: false,
+            isSaving: false
+        }
+    },
+    computed: {
+        // Hide the defense-impact dropdown unless the team actually played
+        // defense, same as MatchTeamRow.vue's create-flow filtering.
+        visibleSections() {
+            return this.schema.map((section) => {
+                if (section.key !== 'postmatch') return section;
+                const playedDefense = section.components.find((c) => c.key === 'played_defense')?.value;
+                return {
+                    ...section,
+                    components: section.components.filter((c) => c.key !== 'defense_impact' || playedDefense)
+                };
+            });
+        }
+    },
+    methods: {
+        colorFor(sectionKey) {
+            if (sectionKey === 'prematch') {
+                return this.matchRow?.prematch_alliance?.toLowerCase() === 'blue' ? 'blue' : 'red';
+            }
+            return 'gray';
+        },
+        async loadMatchData() {
+            this.loaded = false;
+            const id = Number(this.$route.params.id);
+            this.matchRow = await fetchMatchDataById(id);
+            this.schema = this.matchRow ? buildTeamRowSchema({ existingData: this.matchRow }) : [];
+            this.loaded = true;
+        },
+        formValidation() {
+            this.formInvalid = false;
+
+            const { data, valid } = validateForm(this.schema);
+            this.schema = data;
+            this.formInvalid = !valid;
+
+            return valid;
+        },
+        async save() {
+            this.isSaving = true;
+            this.saveSuccess = false;
+            this.queuedOffline = false;
+
+            if (!this.formValidation()) {
+                this.isSaving = false;
+                return;
+            }
+
+            // Reuse the submission's own event, and restore the identity fields
+            // (not part of the editable schema — see match-scouting-form.ts),
+            // so an edit can never reassign which match/team/alliance/event a
+            // submission belongs to.
+            const dbData = parseScoutData(this.schema, this.matchRow.event);
+            dbData.prematch_team_number = this.matchRow.prematch_team_number;
+            dbData.prematch_match_number = this.matchRow.prematch_match_number;
+            dbData.prematch_alliance = this.matchRow.prematch_alliance;
+
+            const error = await updateScoutData(this.matchRow.id, dbData, matchScoutTable);
+
+            if (error) {
+                console.log(error);
+                this.queueStore.enqueue(
+                    'scout_data',
+                    { table: matchScoutTable, data: dbData, id: this.matchRow.id },
+                    error.message ?? String(error)
+                );
+            }
+
+            // Return to Data Status either way (issue #31) — a queue failure
+            // still captured the edit for offline sync.
+            this.isSaving = false;
+            this.$router.push('/data-status');
+        }
+    },
+    created() {
+        this.queueStore = useOfflineQueueStore();
+        this.loadMatchData();
+    }
+}
+</script>
+
+<style scoped>
+.match-context {
+    font-size: 15px;
+    font-weight: 700;
+    text-align: center;
+}
+
+.back-link {
+    display: inline-block;
+    margin-top: 10px;
+}
+
+.button-container {
+    display: flex;
+    justify-content: safe center;
+    align-items: safe center;
+    width: 100%;
+}
+
+md-filled-button {
+    margin: 10px;
+}
+
+md-filled-button.cancel-button {
+    --md-filled-button-container-color: rgba(128, 128, 128, 0.4);
+}
+
+.error-tile {
+    background-color: red;
+    color: white;
+}
+</style>

--- a/src/views/PitScoutingView.vue
+++ b/src/views/PitScoutingView.vue
@@ -13,7 +13,7 @@ import { queryTeamNumbers } from "@/lib/data-query";
             <SearchableDropdown :choices="teamFilters" v-model="currentTeamNumber" placeholder="Search team…">
             </SearchableDropdown>
 
-            <PitScoutingSection :team-number="teamNumber"></PitScoutingSection>
+            <PitScoutingSection :team-number="teamNumber" :auto-edit="autoEditPit"></PitScoutingSection>
         </div>
         <div v-else-if="teamsLoaded">
             <h2>No Data Available</h2>
@@ -28,7 +28,8 @@ export default {
             eventStore: null,
             teamsLoaded: false,
             teamFilters: [],
-            currentTeamNumber: null
+            currentTeamNumber: null,
+            autoEditPit: false
         }
     },
     methods: {
@@ -69,6 +70,21 @@ export default {
     },
     created() {
         this.eventStore = useEventStore();
+
+        // Data Status's lead-only pit-edit shortcut (issue #31) lands here
+        // with ?team=&editPit=1 — capture both, then strip them from the URL
+        // so a refresh/back-nav doesn't keep re-forcing edit mode.
+        const queryTeam = Number(this.$route.query.team);
+        if (Number.isFinite(queryTeam)) {
+            this.currentTeamNumber = queryTeam;
+        }
+        if (this.$route.query.editPit === '1') {
+            this.autoEditPit = true;
+        }
+        if (this.$route.query.team != null || this.$route.query.editPit != null) {
+            this.$router.replace({ path: '/pit' });
+        }
+
         this.loadTeamNumbers();
     }
 }


### PR DESCRIPTION
Adds match-scouting edit (previously nonexistent) via a new /match/edit/:id page, and a lead-only edit pencil next to scouted cells on Data Status for both match and pit data. Match's pencil opens the new edit page; pit's opens the Pit Scouting page pre-selected on that team in edit mode. Both Cancel and Save return to Data Status. The team link itself always goes to Team Analysis regardless of role. Data Status's grids now show team numbers only (no names), and the pencil is sized as a proper touch target.


Closes #31 