### PR TITLE
Let admins filter the pick list to view a scout's personal list 

### DIFF
--- a/docs/picklist.md
+++ b/docs/picklist.md
@@ -137,6 +137,21 @@ The democratic tab shows a read-only ranking computed from all personal lists su
 
 On the **Team List** tab, leads/admins can click **↺ Reset from Democratic** to overwrite the current team list with the current democratic ranking as a starting point, then continue reordering from there. This immediately saves — it's a real overwrite, not a staged draft — so use it when you want to discard the team list's current order, not to preview the democratic results. The button is disabled when no personal lists have been submitted yet (nothing to copy).
 
+### Viewing a Scout's List ([issue #56](https://github.com/Team973/greyscout/issues/56))
+
+On the **My List** tab, admins see a "View scout's list" dropdown above the
+tab description, listing every member/lead/admin by name. Selecting a scout
+swaps the list to a read-only view of that scout's personal picklist for the
+current archetype (Scorer/Defender) — no drag handles, no Save List bar, no
+picked checkbox. Click **✕ Clear Filter** (or pick "My List" from the
+dropdown) to go back to your own editable list. Switching the Scorer/Defender
+archetype tab while a filter is active re-fetches the selected scout's list
+for that archetype, since a personal list is stored per archetype.
+
+The filtered list is held entirely separately from the admin's own personal
+list state, so applying or clearing the filter never touches or risks saving
+over the admin's own draft.
+
 ### Per-Team Rank Stats
 
 Rows on the **Democratic** and **Team List** tabs show four numbers next to each team, summarizing where that team landed across every scout's personal list: **Hi** (highest/best rank any scout gave it), **Lo** (lowest/worst rank), **Avg** (mean rank), and **Med** (median rank). A team no scout has picked yet shows "No picks yet" instead. These numbers reflect the *raw rank position* a team received (1st, 2nd, …) in each personal list — not the democratic score used to order the Democratic tab itself, so a team can have a strong average rank while still sitting lower in the democratic order if fewer scouts included it. This is meant to help leads judge consensus (or disagreement) while building the team list — it isn't shown on **My List**, since a single list has no variance to summarize.

--- a/src/lib/picklist-query.ts
+++ b/src/lib/picklist-query.ts
@@ -293,6 +293,28 @@ export function parseTeamTiers(raw: Record<string, unknown> | null | undefined):
 }
 
 /**
+ * Fetch the scout roster (members/leads/admins, not observers) for the
+ * admin-only "view a scout's pick list" filter (issue #56) — sorted by
+ * name so the dropdown reads alphabetically. Excludes unnamed accounts
+ * (e.g. a still-provisioning profile) since they can't be identified in
+ * the dropdown.
+ */
+export async function fetchScoutRoster(): Promise<{ user_id: string; name: string }[]> {
+    const { data, error } = await supabase
+        .from(userTable)
+        .select('user_id, name')
+        .in('role', ['member', 'lead', 'admin'])
+        .not('name', 'is', null)
+        .order('name', { ascending: true });
+
+    if (error) {
+        console.error('fetchScoutRoster error:', error);
+        return [];
+    }
+    return data ?? [];
+}
+
+/**
  * Fetch the current user's personal picklist for an event/archetype.
  * Returns the ordered array of team_numbers plus tier assignments, or null if none exists.
  */

--- a/src/stores/picklist-store.ts
+++ b/src/stores/picklist-store.ts
@@ -3,6 +3,7 @@
 import { defineStore } from 'pinia';
 import {
     fetchTeamsForPicklist,
+    fetchScoutRoster,
     fetchPersonalPicklist,
     fetchTeamPicklist,
     fetchAllPersonalPicklists,
@@ -101,6 +102,17 @@ export const usePicklistStore = defineStore('picklist', {
             personalTierSections: perArchetype(emptyTierSections) as Record<Archetype, Record<TierGroup, number[]>>,
             personalListLoaded: perArchetype(() => false) as Record<Archetype, boolean>,
 
+            // Admin-only "view a scout's pick list" filter (issue #56) — a
+            // read-only look at one other scout's personal list, kept
+            // entirely separate from the current user's own personalTierSections
+            // so switching the filter on/off never risks clobbering their draft.
+            scoutRoster: [] as { user_id: string; name: string }[],
+            scoutRosterLoaded: false,
+            viewingScoutUserId: null as string | null,
+            viewingScoutName: null as string | null,
+            viewedScoutTierSections: emptyTierSections() as Record<TierGroup, number[]>,
+            viewedScoutListLoading: false,
+
             // Team (lead) list — tier-grouped team numbers per archetype
             teamTierSections: perArchetype(emptyTierSections) as Record<Archetype, Record<TierGroup, number[]>>,
             teamListLoaded: perArchetype(() => false) as Record<Archetype, boolean>,
@@ -141,7 +153,10 @@ export const usePicklistStore = defineStore('picklist', {
 
         /** The tier-grouped sections for whichever tab/archetype is currently active. */
         activeSections(): Record<TierGroup, number[]> {
-            if (this.activeTab === 'personal') return this.personalTierSections[this.activeArchetype];
+            if (this.activeTab === 'personal') {
+                if (this.viewingScoutUserId) return this.viewedScoutTierSections;
+                return this.personalTierSections[this.activeArchetype];
+            }
             if (this.activeTab === 'team') return this.teamTierSections[this.activeArchetype];
             return this.democraticTierSections[this.activeArchetype];
         },
@@ -264,6 +279,43 @@ export const usePicklistStore = defineStore('picklist', {
                 stats
             );
             this.democraticListLoaded[archetype] = true;
+        },
+
+        /**
+         * Loads the scout roster for the admin-only pick-list filter dropdown
+         * (issue #56), excluding the viewing admin themself — they already
+         * have their own list under "My List", there's nothing to filter to.
+         */
+        async loadScoutRoster(excludeUserId: string | null) {
+            this.scoutRosterLoaded = false;
+            const roster = await fetchScoutRoster();
+            this.scoutRoster = roster.filter((s) => s.user_id !== excludeUserId);
+            this.scoutRosterLoaded = true;
+        },
+
+        /**
+         * Load a given scout's personal picklist read-only (issue #56). Kept
+         * out of personalTierSections entirely so it can never be saved over
+         * the viewing admin's own list.
+         */
+        async viewScoutList(scoutUserId: string, scoutName: string, eventId: string, archetype: Archetype) {
+            this.viewingScoutUserId = scoutUserId;
+            this.viewingScoutName = scoutName;
+            this.viewedScoutListLoading = true;
+            const result = await fetchPersonalPicklist(scoutUserId, eventId, archetype);
+            this.viewedScoutTierSections = buildTierSections(
+                result?.team_numbers ?? [],
+                parseTeamTiers(result?.team_tiers),
+                this.allTeams
+            );
+            this.viewedScoutListLoading = false;
+        },
+
+        /** Clears the scout filter, returning the My List tab to the current user's own editable list. */
+        clearScoutFilter() {
+            this.viewingScoutUserId = null;
+            this.viewingScoutName = null;
+            this.viewedScoutTierSections = emptyTierSections();
         },
 
         async loadPickedTeams(eventId: string) {

--- a/src/views/PicklistView.vue
+++ b/src/views/PicklistView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 // @ts-nocheck
-import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import draggable from 'vuedraggable';
 import Papa from 'papaparse';
 import { usePicklistStore } from '@/stores/picklist-store';
@@ -12,6 +12,7 @@ import { TIERS, TIER_GROUPS } from '@/lib/picklist-query';
 import { refreshTbaStats } from '@/lib/tba-cache';
 import PicklistRow from '@/components/PicklistRow.vue';
 import PicklistUnrankedCard from '@/components/PicklistUnrankedCard.vue';
+import SearchableDropdown from '@/components/SearchableDropdown.vue';
 
 const picklistStore = usePicklistStore();
 const authStore = useAuthStore();
@@ -106,6 +107,7 @@ onUnmounted(onDragEnd);
 // ─── Computed helpers ──────────────────────────────────────────────────────────
 
 const isLead = computed(() => authStore.isLead);
+const isAdmin = computed(() => authStore.isAdmin);
 const isObserver = computed(() => authStore.isObserver);
 const userId = computed(() => authStore.currentUserId);
 const eventId = computed(() => eventStore.eventId);
@@ -123,7 +125,7 @@ const activeArchetype = computed({
 });
 
 const isEditable = computed(() =>
-    (activeTab.value === 'personal') ||
+    (activeTab.value === 'personal' && !picklistStore.viewingScoutUserId) ||
     (activeTab.value === 'team' && isLead.value)
 );
 
@@ -147,6 +149,45 @@ onMounted(async () => {
     await eventStore.updateEvent();
     await picklistStore.loadAll(eventId.value, userId.value, isLead.value);
     await watchlistStore.loadWatchlist(eventId.value);
+    if (isAdmin.value) {
+        await picklistStore.loadScoutRoster(userId.value);
+    }
+});
+
+// ─── Admin scout filter (issue #56) ────────────────────────────────────────────
+// Lets an admin pull up a read-only view of one scout's personal pick list.
+// Kept out of personalTierSections entirely (see viewScoutList) so it can
+// never be saved over the viewing admin's own list.
+
+const scoutFilterChoices = computed(() => [
+    { key: '', text: 'My List' },
+    ...picklistStore.scoutRoster.map((s) => ({ key: s.user_id, text: s.name }))
+]);
+
+const selectedScoutId = computed({
+    get: () => picklistStore.viewingScoutUserId ?? '',
+    set: async (scoutUserId: string) => {
+        if (!scoutUserId) {
+            picklistStore.clearScoutFilter();
+            return;
+        }
+        const scout = picklistStore.scoutRoster.find((s) => s.user_id === scoutUserId);
+        await picklistStore.viewScoutList(scoutUserId, scout?.name ?? 'Unknown', eventId.value, activeArchetype.value);
+    }
+});
+
+function clearScoutFilter() {
+    picklistStore.clearScoutFilter();
+}
+
+// The Scorer/Defender archetype tabs apply to the filtered scout's list too
+// — a personal picklist is stored per archetype, so switching archetype
+// while a filter is active has to re-fetch that scout's other list.
+watch(activeArchetype, async (archetype) => {
+    if (!picklistStore.viewingScoutUserId) return;
+    await picklistStore.viewScoutList(
+        picklistStore.viewingScoutUserId, picklistStore.viewingScoutName, eventId.value, archetype
+    );
 });
 
 // ─── Expand / collapse row ────────────────────────────────────────────────────
@@ -386,9 +427,23 @@ function toggleTierCollapse(group: string) {
                 </button>
             </div>
 
+            <!-- Admin scout filter (issue #56) — pull up a read-only view of one
+                 scout's personal list, only on the My List tab. -->
+            <div v-if="isAdmin && activeTab === 'personal'" class="picklist-scout-filter">
+                <span class="picklist-scout-filter-label">View scout's list:</span>
+                <SearchableDropdown :choices="scoutFilterChoices" :model-value="selectedScoutId"
+                    placeholder="Search scouts…" @update:modelValue="selectedScoutId = $event"></SearchableDropdown>
+                <button v-if="picklistStore.viewingScoutUserId" id="btn-clear-scout-filter" type="button"
+                    class="picklist-reset-btn" title="Return to your own editable list" @click="clearScoutFilter">
+                    ✕ Clear Filter
+                </button>
+            </div>
+
             <!-- Tab description -->
             <div class="picklist-tab-description">
-                <span v-if="activeTab === 'personal'">Your personal tier ranking. Drag rows between tiers or reorder
+                <span v-if="activeTab === 'personal' && picklistStore.viewingScoutUserId">
+                    {{ picklistStore.viewingScoutName }}'s personal tier ranking (read-only).</span>
+                <span v-else-if="activeTab === 'personal'">Your personal tier ranking. Drag rows between tiers or reorder
                     within a tier, then save.</span>
                 <span v-else-if="activeTab === 'democratic'">Aggregated tier ranking from all scouts' personal lists
                     (read-only).</span>
@@ -396,7 +451,8 @@ function toggleTierCollapse(group: string) {
             </div>
 
             <!-- Loading state -->
-            <div v-if="!picklistStore.teamsLoaded" class="picklist-loading">
+            <div v-if="!picklistStore.teamsLoaded || (picklistStore.viewingScoutUserId && picklistStore.viewedScoutListLoading)"
+                class="picklist-loading">
                 <div class="picklist-spinner"></div>
                 <span>Loading teams…</span>
             </div>
@@ -692,6 +748,20 @@ function toggleTierCollapse(group: string) {
     color: rgba(128, 128, 128, 0.75);
     min-height: 20px;
     margin-bottom: 16px;
+}
+
+/* ── Admin scout filter (issue #56) ── */
+.picklist-scout-filter {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 10px 0;
+    font-size: 13px;
+}
+
+.picklist-scout-filter-label {
+    color: rgba(128, 128, 128, 0.85);
+    font-weight: 600;
 }
 
 /* ── Loading ── */


### PR DESCRIPTION
Closes #56

Admins get a searchable "View scout's list" filter (matching the SearchableDropdown used elsewhere) above the My List tab, showing a read-only view of any other scout's personal picklist for the current archetype. The filtered list is stored separately from the admin's own personal list state so it can never be saved over, and the admin themself is excluded from the roster since they already have their own list.